### PR TITLE
Expose object metadata from `Bucket.list`

### DIFF
--- a/.github/workflows/gcloud.yml
+++ b/.github/workflows/gcloud.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.19.0, dev]
+        sdk: [3.0.0, dev]
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672

--- a/pkgs/gcloud/CHANGELOG.md
+++ b/pkgs/gcloud/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 0.8.16-wip
 
+ - **Breaking** `BucketEntry` is now `sealed` anyone implementing or subclassing
+   will experience breakage.
+ - Feature `BucketEntry` objects returns from `Bucket.list` are now instances
+   of:
+    * `BucketDirectoryEntry`, or,
+    * `BucketObjectEntry`, which implements `ObjectInfo` exposing metadata.
+
+   This means that anyone using `Bucket.list` to find objects, does not need
+   to use `Bucket.info` to fetch metadata for an object.
+ - Minimum Dart SDK constraint bumped to `^3.0.0`.
+
 ## 0.8.15
 
 - Update the pubspec repository field to reflect the repo move.

--- a/pkgs/gcloud/lib/src/storage_impl.dart
+++ b/pkgs/gcloud/lib/src/storage_impl.dart
@@ -349,9 +349,9 @@ class _ObjectPageImpl implements Page<BucketEntry> {
       storage_api.Objects response)
       : items = [
           for (final item in response.prefixes ?? const <String>[])
-            BucketEntry._directory(item),
+            BucketDirectoryEntry._(item),
           for (final item in response.items ?? const <storage_api.Object>[])
-            BucketEntry._object(item.name!)
+            _BucketObjectEntry(item)
         ],
         _nextPageToken = response.nextPageToken;
 
@@ -428,6 +428,16 @@ class _ObjectInfoImpl implements ObjectInfo {
   /// Additional metadata.
   @override
   ObjectMetadata get metadata => _metadata;
+}
+
+class _BucketObjectEntry extends _ObjectInfoImpl implements BucketObjectEntry {
+  _BucketObjectEntry(storage_api.Object object) : super(object);
+
+  @override
+  bool get isDirectory => false;
+
+  @override
+  bool get isObject => true;
 }
 
 class _ObjectMetadata implements ObjectMetadata {

--- a/pkgs/gcloud/lib/storage.dart
+++ b/pkgs/gcloud/lib/storage.dart
@@ -668,22 +668,37 @@ abstract class ObjectMetadata {
 /// Listing operate like a directory listing, despite the object
 /// namespace being flat.
 ///
+/// Instances of [BucketEntry] are either instances of [BucketDirectoryEntry]
+/// or [BucketObjectEntry]. Casting to [BucketObjectEntry] will give access to
+/// object metadata.
+///
 /// See [Bucket.list] for information on how the hierarchical structure
 /// is determined.
-class BucketEntry {
+sealed class BucketEntry {
   /// Whether this is information on an object.
-  final bool isObject;
+  bool get isObject;
 
   /// Name of object or directory.
-  final String name;
-
-  BucketEntry._object(this.name) : isObject = true;
-
-  BucketEntry._directory(this.name) : isObject = false;
+  String get name;
 
   /// Whether this is a prefix.
   bool get isDirectory => !isObject;
 }
+
+/// Entry in [Bucket.list] representing a directory given the `delimiter`
+/// passed.
+class BucketDirectoryEntry extends BucketEntry {
+  @override
+  final String name;
+
+  BucketDirectoryEntry._(this.name);
+
+  @override
+  bool get isObject => false;
+}
+
+/// Entry in [Bucket.list] representing an object.
+abstract class BucketObjectEntry implements BucketEntry, ObjectInfo {}
 
 /// Access to operations on a specific cloud storage bucket.
 abstract class Bucket {

--- a/pkgs/gcloud/pubspec.yaml
+++ b/pkgs/gcloud/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
  - gcp
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '^3.0.0'
 
 dependencies:
   _discoveryapis_commons: ^1.0.0


### PR DESCRIPTION
This is a slightly breaking change, mostly for people who are subclassing `BucketEntry`.

Which someone might do if they are mocking or faking objects for testing.

But for almost everyone else this is a non-breaking change.

We could avoid adding `sealed`, but then switch'ing on `BucketEntry` wouldn't be exhaustive.