### PR TITLE
Fix bug in `ObjectMetadata.replace` -- release gcloud

### DIFF
--- a/pkgs/gcloud/CHANGELOG.md
+++ b/pkgs/gcloud/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.17
+ - Fix bug in `ObjectMetadata.replace` where  `contentEncoding` overwrote
+   `contentDisposition` and `contentLanguage`.
+
 ## 0.8.16
 
  - `BucketEntry` is now `sealed` this may cause **breakage** for anyone

--- a/pkgs/gcloud/lib/src/storage_impl.dart
+++ b/pkgs/gcloud/lib/src/storage_impl.dart
@@ -514,8 +514,8 @@ class _ObjectMetadata implements ObjectMetadata {
         contentType: contentType ?? this.contentType,
         contentEncoding: contentEncoding ?? this.contentEncoding,
         cacheControl: cacheControl ?? this.cacheControl,
-        contentDisposition: contentDisposition ?? this.contentEncoding,
-        contentLanguage: contentLanguage ?? this.contentEncoding,
+        contentDisposition: contentDisposition ?? this.contentDisposition,
+        contentLanguage: contentLanguage ?? this.contentLanguage,
         custom: custom != null ? Map.from(custom) : this.custom);
   }
 }

--- a/pkgs/gcloud/pubspec.yaml
+++ b/pkgs/gcloud/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.8.16
+version: 0.8.17
 description: >-
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.
 repository: https://github.com/dart-lang/labs/tree/main/pkgs/gcloud


### PR DESCRIPTION
Fix bug in `ObjectMetadata.replace` where  `contentEncoding` overwrote `contentDisposition` and `contentLanguage`.
