### PR TITLE
Fix updateMetadata in gcloud, release 0.8.18

### DIFF
--- a/pkgs/gcloud/CHANGELOG.md
+++ b/pkgs/gcloud/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.18
+ - Fix bug in `Bucket.updateMetadata` such that `acl: null` is allowed.
+   Since, this is the only valid value for buckets with uniform access policies.
+
 ## 0.8.17
  - Fix bug in `ObjectMetadata.replace` where  `contentEncoding` overwrote
    `contentDisposition` and `contentLanguage`.

--- a/pkgs/gcloud/lib/src/storage_impl.dart
+++ b/pkgs/gcloud/lib/src/storage_impl.dart
@@ -286,13 +286,13 @@ class _BucketImpl implements Bucket {
     // TODO: support other ObjectMetadata implementations?
     var md = metadata as _ObjectMetadata;
     var object = md._object;
-    if (md._object.acl == null && _defaultObjectAcl == null) {
-      throw ArgumentError('ACL is required for update');
-    }
     if (md.contentType == null) {
       throw ArgumentError('Content-Type is required for update');
     }
-    md._object.acl ??= _defaultObjectAcl!._toObjectAccessControlList();
+    // If no ACL is passed use the default (if any).
+    if (object.acl == null && _defaultObjectAcl != null) {
+      object.acl = _defaultObjectAcl!._toObjectAccessControlList();
+    }
     return _api.objects.update(object, bucketName, objectName);
   }
 

--- a/pkgs/gcloud/pubspec.yaml
+++ b/pkgs/gcloud/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.8.17
+version: 0.8.18
 description: >-
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.
 repository: https://github.com/dart-lang/labs/tree/main/pkgs/gcloud

--- a/pkgs/gcloud/test/storage/e2e_test.dart
+++ b/pkgs/gcloud/test/storage/e2e_test.dart
@@ -341,5 +341,31 @@ void main() {
         ], (Function f) => f().then(expectAsync1((_) {})));
       });
     });
+
+    test('update-metadata', () {
+      return withTestBucket((Bucket bucket) async {
+        await bucket.writeBytes(
+          'test-m',
+          metadata: ObjectMetadata(
+            contentType: 'application/test-1',
+          ),
+          [1, 2, 3],
+        );
+
+        final info = await bucket.info('test-m');
+        expect(info.metadata.contentType, 'application/test-1');
+
+        await bucket.updateMetadata(
+            'test-m',
+            ObjectMetadata(
+              contentType: 'application/test-2',
+            ));
+
+        final info2 = await bucket.info('test-m');
+        expect(info2.metadata.contentType, 'application/test-2');
+
+        await bucket.delete('test-m');
+      });
+    });
   });
 }


### PR DESCRIPTION
Buckets with uniform access policies need `acl: null`.

![image](https://github.com/user-attachments/assets/df21d69c-59a1-40b7-8d21-30566fa80955)
