### PR TITLE
Implement `readAsBytes` for Windows

### DIFF
--- a/.github/workflows/io_file.yml
+++ b/.github/workflows/io_file.yml
@@ -53,8 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         sdk: [stable]
-        # TODO(brianquinlan): Run benchmarks on Windows.
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/pkgs/io_file/lib/src/internal_constants.dart
+++ b/pkgs/io_file/lib/src/internal_constants.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// The maximum number of bytes to read in a single call to `read`.
+//
+// On macOS, it is an error to call
+// `read/_read(fildes, buf, nbyte)` with `nbyte >= INT_MAX`.
+//
+// The POSIX specification states that the behavior of `read` is
+// implementation-defined if `nbyte > SSIZE_MAX`. On Linux, the `read` will
+// transfer at most 0x7ffff000 bytes and return the number of bytes actually.
+// transfered.
+//
+// A smaller value has the advantage of making vm-service clients
+// (e.g. debugger) more responsive.
+//
+// A bigger value reduces the number of system calls.
+const int maxReadSize = 16 * 1024 * 1024; // 16MB.
+
+// If the size of a file is unknown, read in blocks of this size.
+const int blockSize = 64 * 1024;

--- a/pkgs/io_file/lib/src/vm_posix_file_system.dart
+++ b/pkgs/io_file/lib/src/vm_posix_file_system.dart
@@ -12,27 +12,7 @@ import 'package:meta/meta.dart';
 import 'package:stdlibc/stdlibc.dart' as stdlibc;
 
 import 'file_system.dart';
-
-// The maximum number of bytes to read in a single call to `read`.
-//
-// On macOS, it is an error to call
-// `read/_read(fildes, buf, nbyte)` with `nbyte >= INT_MAX`.
-//
-// The POSIX specification states that the behavior of `read` is
-// implementation-defined if `nbyte > SSIZE_MAX`. On Linux, the `read` will
-// transfer at most 0x7ffff000 bytes and return the number of bytes actually.
-// transfered.
-//
-// A smaller value has the advantage of making vm-service clients
-// (e.g. debugger) more responsive.
-//
-// A bigger value reduces the number of system calls.
-@visibleForTesting
-const int maxReadSize = 16 * 1024 * 1024; // 16MB.
-
-// If the size of a file is unknown, read in blocks of this size.
-@visibleForTesting
-const int blockSize = 64 * 1024;
+import 'internal_constants.dart';
 
 Exception _getError(int errno, String message, String path) {
   //TODO(brianquinlan): In the long-term, do we need to avoid exceptions that
@@ -87,28 +67,27 @@ base class PosixFileSystem extends FileSystem {
     }
     try {
       final stat = stdlibc.fstat(fd);
-      if (stat != null &&
-          stat.st_size == 0 &&
-          stat.st_mode & stdlibc.S_IFREG != 0) {
-        return Uint8List(0);
+      // The POSIX specification only defines the meaning of `st_size` for
+      // regular files and symbolic links.
+      if (stat != null && stat.st_mode & stdlibc.S_IFREG != 0) {
+        if (stat.st_size == 0) {
+          return Uint8List(0);
+        } else {
+          return _readKnownLength(path, fd, stat.st_size);
+        }
       }
-      final length = stat?.st_size ?? 0;
-      if (length == 0) {
-        return _readUnknownLength(path, fd);
-      } else {
-        return _readKnownLength(path, fd, length);
-      }
+      return _readUnknownLength(path, fd);
     } finally {
       stdlibc.close(fd);
     }
   }
 
   Uint8List _readUnknownLength(String path, int fd) => ffi.using((arena) {
-    final buf = ffi.malloc<Uint8>(blockSize);
+    final buffer = arena<Uint8>(blockSize);
     final builder = BytesBuilder(copy: true);
 
     while (true) {
-      final r = _tempFailureRetry(() => read(fd, buf, blockSize));
+      final r = _tempFailureRetry(() => read(fd, buffer, blockSize));
       switch (r) {
         case -1:
           final errno = stdlibc.errno;
@@ -116,7 +95,7 @@ base class PosixFileSystem extends FileSystem {
         case 0:
           return builder.takeBytes();
         default:
-          final typed = buf.asTypedList(r);
+          final typed = buffer.asTypedList(r);
           builder.add(typed);
       }
     }
@@ -137,7 +116,7 @@ base class PosixFileSystem extends FileSystem {
       switch (r) {
         case -1:
           final errno = stdlibc.errno;
-          ffi.calloc.free(buffer);
+          ffi.malloc.free(buffer);
           throw _getError(errno, 'read failed', path);
         case 0:
           return buffer.asTypedList(

--- a/pkgs/io_file/lib/src/vm_posix_file_system.dart
+++ b/pkgs/io_file/lib/src/vm_posix_file_system.dart
@@ -8,7 +8,6 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart' as ffi;
-import 'package:meta/meta.dart';
 import 'package:stdlibc/stdlibc.dart' as stdlibc;
 
 import 'file_system.dart';

--- a/pkgs/io_file/lib/src/vm_windows_file_system.dart
+++ b/pkgs/io_file/lib/src/vm_windows_file_system.dart
@@ -179,13 +179,12 @@ base class WindowsFileSystem extends FileSystem {
             throw _getError(errorCode, 'read failed', path);
           }
 
+          bufferOffset += bytesRead.value;
           if (bytesRead.value == 0) {
             return buffer.asTypedList(
               bufferOffset,
               finalizer: ffi.calloc.nativeFree,
             );
-          } else {
-            bufferOffset += bytesRead.value;
           }
         }
         return buffer.asTypedList(length, finalizer: ffi.calloc.nativeFree);

--- a/pkgs/io_file/lib/src/vm_windows_file_system.dart
+++ b/pkgs/io_file/lib/src/vm_windows_file_system.dart
@@ -9,7 +9,6 @@ import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
 import 'package:ffi/ffi.dart' as ffi;
-import 'package:meta/meta.dart';
 import 'package:win32/win32.dart' as win32;
 
 import 'file_system.dart';

--- a/pkgs/io_file/lib/src/vm_windows_file_system.dart
+++ b/pkgs/io_file/lib/src/vm_windows_file_system.dart
@@ -180,15 +180,15 @@ base class WindowsFileSystem extends FileSystem {
             final errorCode = win32.GetLastError();
             throw _getError(errorCode, 'read failed', path);
           }
+          bufferOffset += bytesRead.value;
+          if (bytesRead.value == 0) {
+            break;
+          }
         }
-
-        bufferOffset += bytesRead.value;
-        if (bytesRead.value == 0) {
-          return buffer.asTypedList(
-            bufferOffset,
-            finalizer: ffi.malloc.nativeFree,
-          );
-        }
+        return buffer.asTypedList(
+          bufferOffset,
+          finalizer: ffi.malloc.nativeFree,
+        );
       });
     } on Exception {
       ffi.malloc.free(buffer);

--- a/pkgs/io_file/lib/src/vm_windows_file_system.dart
+++ b/pkgs/io_file/lib/src/vm_windows_file_system.dart
@@ -4,11 +4,16 @@
 
 import 'dart:ffi';
 import 'dart:io' as io;
+import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
+import 'package:ffi/ffi.dart' as ffi;
+import 'package:meta/meta.dart';
 import 'package:win32/win32.dart' as win32;
 
 import 'file_system.dart';
+import 'internal_constants.dart';
 
 String _formatMessage(int errorCode) {
   final buffer = win32.wsalloc(1024);
@@ -80,4 +85,110 @@ base class WindowsFileSystem extends FileSystem {
       throw _getError(errorCode, 'rename failed', oldPath);
     }
   });
+
+  @override
+  Uint8List readAsBytes(String path) => using((arena) {
+    // Calling `GetLastError` for the first time causes the `GetLastError`
+    // symbol to be loaded, which resets `GetLastError`. So make a harmless
+    // call before the value is needed.
+    win32.GetLastError();
+
+    final f = win32.CreateFile(
+      path.toNativeUtf16(),
+      win32.GENERIC_READ | win32.FILE_SHARE_READ,
+      win32.FILE_SHARE_READ | win32.FILE_SHARE_WRITE,
+      nullptr,
+      win32.OPEN_EXISTING,
+      win32.FILE_ATTRIBUTE_NORMAL,
+      0,
+    );
+    if (f == win32.INVALID_HANDLE_VALUE) {
+      final errorCode = win32.GetLastError();
+      throw _getError(errorCode, 'open failed', path);
+    }
+    try {
+      // The result of `GetFileSize` is not defined for non-seeking devices
+      // such as pipes.
+      if (win32.GetFileType(f) == win32.FILE_TYPE_DISK) {
+        final highFileSize = arena<win32.DWORD>();
+        final lowFileSize = win32.GetFileSize(f, highFileSize);
+        if (lowFileSize == 0xffffffff) {
+          // Indicates an error OR that the low order word of the is actually
+          // that constant.
+          final errorCode = win32.GetLastError();
+          if (errorCode != win32.ERROR_SUCCESS) {
+            return _readUnknownLength(path, f);
+          }
+        }
+        final fileSize = highFileSize.value << 32 | lowFileSize;
+        if (fileSize == 0) {
+          return Uint8List(0);
+        } else {
+          return _readKnownLength(path, f, fileSize);
+        }
+      }
+      return _readUnknownLength(path, f);
+    } finally {
+      win32.CloseHandle(f);
+    }
+  });
+
+  Uint8List _readUnknownLength(String path, int file) => ffi.using((arena) {
+    final buffer = arena<Uint8>(blockSize);
+    final bytesRead = arena<win32.DWORD>();
+    final builder = BytesBuilder(copy: true);
+
+    while (true) {
+      if (win32.ReadFile(file, buffer, blockSize, bytesRead, nullptr) ==
+          win32.FALSE) {
+        final errorCode = win32.GetLastError();
+        // On Windows, reading from a pipe that is closed by the writer results
+        // in ERROR_BROKEN_PIPE.
+        if (errorCode == win32.ERROR_BROKEN_PIPE ||
+            errorCode == win32.ERROR_SUCCESS) {
+          return builder.takeBytes();
+        }
+        throw _getError(errorCode, 'read failed', path);
+      }
+
+      if (bytesRead.value == 0) {
+        return builder.takeBytes();
+      } else {
+        final typed = buffer.asTypedList(bytesRead.value);
+        builder.add(typed);
+      }
+    }
+  });
+
+  Uint8List _readKnownLength(String path, int file, int length) =>
+      ffi.using((arena) {
+        final buffer = ffi.malloc<Uint8>(length);
+        final bytesRead = arena<win32.DWORD>();
+        var bufferOffset = 0;
+
+        while (bufferOffset < length) {
+          if (win32.ReadFile(
+                file,
+                (buffer + bufferOffset).cast(),
+                min(length - bufferOffset, maxReadSize),
+                bytesRead,
+                nullptr,
+              ) ==
+              win32.FALSE) {
+            ffi.malloc.free(buffer);
+            final errorCode = win32.GetLastError();
+            throw _getError(errorCode, 'read failed', path);
+          }
+
+          if (bytesRead.value == 0) {
+            return buffer.asTypedList(
+              bufferOffset,
+              finalizer: ffi.calloc.nativeFree,
+            );
+          } else {
+            bufferOffset += bytesRead.value;
+          }
+        }
+        return buffer.asTypedList(length, finalizer: ffi.calloc.nativeFree);
+      });
 }

--- a/pkgs/io_file/pubspec.yaml
+++ b/pkgs/io_file/pubspec.yaml
@@ -21,3 +21,4 @@ dev_dependencies:
   benchmark_harness: ^2.3.1
   dart_flutter_team_lints: ^3.4.0
   test: ^1.24.0
+  uuid: ^4.5.1

--- a/pkgs/io_file/pubspec.yaml
+++ b/pkgs/io_file/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 
 dependencies:
   ffi: ^2.1.4
-  meta: ^1.16.0
   stdlibc:
     git:
       # Change this to a released version.

--- a/pkgs/io_file/test/fifo.dart
+++ b/pkgs/io_file/test/fifo.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'fifo_posix.dart';
+import 'fifo_windows.dart';
+
+/// An abstraction for a write-only object with a path.
+///
+/// Used to test reading from a file that does not report a reliable length.
+abstract class Fifo {
+  static Future<Fifo> create(String suggestedPath) {
+    if (Platform.isWindows) {
+      return FifoWindows.create(suggestedPath);
+    } else {
+      return FifoPosix.create(suggestedPath);
+    }
+  }
+
+  /// The file system path of the Fifo used to read it.
+  String get path;
+
+  /// Writes data to the [Fifo]. Does not block.
+  void write(Uint8List data);
+
+  /// Inserts a delay between the next [write] or [close]. Does not block.
+  void delay(Duration d);
+
+  /// Closes the [Fifo]. Does not block.
+  void close();
+}

--- a/pkgs/io_file/test/fifo_posix.dart
+++ b/pkgs/io_file/test/fifo_posix.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:stdlibc/stdlibc.dart' as stdlibc;
+
+import 'fifo.dart';
+
+/// Implements a [Fifo] using POSIX fifos.
+class FifoPosix implements Fifo {
+  final SendPort _sendChannel;
+
+  @override
+  final String path;
+
+  FifoPosix._(this.path, this._sendChannel);
+
+  static Future<FifoPosix> create(String suggestedPath) async {
+    final p = ReceivePort();
+
+    stdlibc.mkfifo(suggestedPath, 438); // 0436 => permissions: -rw-rw-rw-
+
+    await Isolate.spawn<SendPort>((port) {
+      final receivePort = ReceivePort();
+      port.send(receivePort.sendPort);
+
+      final fd = stdlibc.open(
+        suggestedPath,
+        flags: stdlibc.O_WRONLY | stdlibc.O_CLOEXEC,
+      );
+
+      if (fd == -1) {
+        throw AssertionError('could not open fifo: ${stdlibc.errno}');
+      }
+      late final StreamSubscription<dynamic> subscription;
+      Future<void> pause(Duration d) async {
+        subscription.pause();
+        await Future<void>.delayed(d);
+        subscription.resume();
+      }
+
+      subscription = receivePort.listen(
+        (message) => switch (message) {
+          Uint8List data => stdlibc.write(fd, data),
+
+          Duration d => pause(d),
+          null => stdlibc.close(fd),
+
+          final other => throw UnsupportedError('unexpected message: $other'),
+        },
+      );
+    }, p.sendPort);
+    return FifoPosix._(suggestedPath, (await p.first) as SendPort);
+  }
+
+  @override
+  void write(Uint8List data) {
+    _sendChannel.send(data);
+  }
+
+  @override
+  void delay(Duration d) {
+    _sendChannel.send(d);
+  }
+
+  @override
+  void close() {
+    _sendChannel.send(null);
+  }
+}

--- a/pkgs/io_file/test/fifo_windows.dart
+++ b/pkgs/io_file/test/fifo_windows.dart
@@ -1,0 +1,108 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:ffi/ffi.dart' as ffi;
+import 'package:uuid/uuid.dart';
+import 'package:win32/win32.dart' as win32;
+
+import 'fifo.dart';
+
+/// Implements a [Fifo] using Windows named pipes.
+class FifoWindows implements Fifo {
+  final SendPort _sendChannel;
+
+  @override
+  final String path;
+
+  FifoWindows._(this.path, this._sendChannel);
+
+  static Future<FifoWindows> create(String suggestedPath) => ffi.using((
+    arena,
+  ) async {
+    final path = r'\\.\pipe\test' + const Uuid().v4();
+    win32.GetLastError();
+    final f = win32.CreateNamedPipe(
+      path.toNativeUtf16(allocator: arena),
+      win32.PIPE_ACCESS_OUTBOUND | win32.FILE_FLAG_FIRST_PIPE_INSTANCE,
+      win32.PIPE_TYPE_BYTE |
+          win32.PIPE_READMODE_BYTE |
+          win32.PIPE_WAIT |
+          win32.PIPE_REJECT_REMOTE_CLIENTS,
+      win32.PIPE_UNLIMITED_INSTANCES,
+      512, // outBufferSize,
+      512, // inBufferSize
+      0, // timeout in milliseconds
+      nullptr,
+    );
+    if (f == win32.INVALID_HANDLE_VALUE) {
+      throw AssertionError('could not create pipe: ${win32.GetLastError()}');
+    }
+    final p = ReceivePort();
+    await Isolate.spawn<SendPort>((port) {
+      // Calling `GetLastError` for the first time causes the `GetLastError`
+      // symbol to be loaded, which resets `GetLastError`. So make a harmless
+      // call before the value is needed.
+      win32.GetLastError();
+
+      final receivePort = ReceivePort();
+      port.send(receivePort.sendPort);
+
+      if (win32.ConnectNamedPipe(f, nullptr) == win32.FALSE) {
+        final error = win32.GetLastError();
+        throw AssertionError('error waiting for client connection: $error');
+      }
+
+      late final StreamSubscription<dynamic> subscription;
+
+      Future<void> pause(Duration d) async {
+        subscription.pause();
+        await Future<void>.delayed(d);
+        subscription.resume();
+      }
+
+      void write(Uint8List data) {
+        final buffer = arena.allocate<Uint8>(data.length);
+        buffer.asTypedList(data.length).setAll(0, data);
+        final bytesWritten = arena<win32.DWORD>();
+        if (win32.WriteFile(f, buffer, data.length, bytesWritten, nullptr) ==
+            win32.FALSE) {
+          final error = win32.GetLastError();
+          throw AssertionError('could not write to pipe: $error');
+        }
+        assert(bytesWritten.value == data.length);
+      }
+
+      subscription = receivePort.listen(
+        (message) => switch (message) {
+          Uint8List data => write(data),
+          Duration d => pause(d),
+          null => win32.CloseHandle(f),
+
+          final other => throw UnsupportedError('unexpected message: $other'),
+        },
+      );
+    }, p.sendPort);
+    return FifoWindows._(path, (await p.first) as SendPort);
+  });
+
+  @override
+  void write(Uint8List data) {
+    _sendChannel.send(data);
+  }
+
+  @override
+  void delay(Duration d) {
+    _sendChannel.send(d);
+  }
+
+  @override
+  void close() {
+    _sendChannel.send(null);
+  }
+}

--- a/pkgs/io_file/test/fifo_windows.dart
+++ b/pkgs/io_file/test/fifo_windows.dart
@@ -55,7 +55,12 @@ class FifoWindows implements Fifo {
 
       if (win32.ConnectNamedPipe(f, nullptr) == win32.FALSE) {
         final error = win32.GetLastError();
-        throw AssertionError('error waiting for client connection: $error');
+        if (error !=
+            // The client connected in the time between the pipe's creation and
+            // the call to `ConnectNamedPipe`.
+            win32.ERROR_PIPE_CONNECTED) {
+          throw AssertionError('error waiting for client connection: $error');
+        }
       }
 
       late final StreamSubscription<dynamic> subscription;

--- a/pkgs/io_file/test/fifo_windows.dart
+++ b/pkgs/io_file/test/fifo_windows.dart
@@ -35,8 +35,8 @@ class FifoWindows implements Fifo {
           win32.PIPE_WAIT |
           win32.PIPE_REJECT_REMOTE_CLIENTS,
       win32.PIPE_UNLIMITED_INSTANCES,
-      512, // outBufferSize,
-      512, // inBufferSize
+      512, // outBufferSize in bytes,
+      512, // inBufferSize in bytes
       0, // timeout in milliseconds
       nullptr,
     );


### PR DESCRIPTION
- Adds `readAsBytes` for Windows
- Refactors `FifoWriter` into a Windows and POSIX implementation
- Enables benchmarking for Windows

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
