### PR TITLE
Add support for `same` on POSIX

### DIFF
--- a/pkgs/io_file/lib/src/file_system.dart
+++ b/pkgs/io_file/lib/src/file_system.dart
@@ -30,6 +30,18 @@ class WriteMode {
 
 /// An abstract representation of a file system.
 base class FileSystem {
+  /// Checks whether two paths refer to the same object in the file system.
+  ///
+  /// Throws `PathNotFoundException` if either path doesn't exist.
+  ///
+  /// Links are resolved before determining if the paths refer to the same
+  /// object. Throws `PathNotFoundException` if either path requires resolving
+  /// a broken link.
+  /// ```
+  bool same(String path1, String path2) {
+    throw UnsupportedError('same');
+  }
+
   /// Renames, and possibly moves a file system object from one path to another.
   ///
   /// If `newPath` is a relative path, it is resolved against the current

--- a/pkgs/io_file/lib/src/vm_posix_file_system.dart
+++ b/pkgs/io_file/lib/src/vm_posix_file_system.dart
@@ -58,6 +58,23 @@ external int write(int fd, Pointer<Uint8> buf, int count);
 /// macOS).
 base class PosixFileSystem extends FileSystem {
   @override
+  bool same(String path1, String path2) {
+    final stat1 = stdlibc.stat(path1);
+    if (stat1 == null) {
+      final errno = stdlibc.errno;
+      throw _getError(errno, 'stat failed', path1);
+    }
+
+    final stat2 = stdlibc.stat(path2);
+    if (stat2 == null) {
+      final errno = stdlibc.errno;
+      throw _getError(errno, 'stat failed', path2);
+    }
+
+    return (stat1.st_ino == stat2.st_ino) && (stat1.st_dev == stat2.st_dev);
+  }
+
+  @override
   void rename(String oldPath, String newPath) {
     // See https://pubs.opengroup.org/onlinepubs/000095399/functions/rename.html
     if (stdlibc.rename(oldPath, newPath) != 0) {

--- a/pkgs/io_file/test/same_test.dart
+++ b/pkgs/io_file/test/same_test.dart
@@ -1,0 +1,224 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('posix')
+library;
+
+import 'dart:io';
+
+import 'package:io_file/io_file.dart';
+import 'package:stdlibc/stdlibc.dart' as stdlibc;
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  group('same', () {
+    late String tmp;
+    late Directory cwd;
+
+    setUp(() {
+      tmp = createTemp('same');
+      cwd = Directory.current;
+    });
+
+    tearDown(() {
+      Directory.current = cwd;
+      deleteTemp(tmp);
+    });
+
+    //TODO(brianquinlan): test with a very long path.
+
+    test('path1 does not exist', () {
+      final path1 = '$tmp/file1';
+      final path2 = '$tmp/file2';
+      File(path2).writeAsStringSync('Hello World');
+
+      expect(
+        () => fileSystem.same(path1, path2),
+        throwsA(
+          isA<PathNotFoundException>()
+              .having((e) => e.message, 'message', 'stat failed')
+              .having((e) => e.path, 'path', path1)
+              .having((e) => e.osError?.errorCode, 'errorCode', stdlibc.ENOENT),
+        ),
+      );
+    });
+
+    test('path2 does not exist', () {
+      final path1 = '$tmp/file1';
+      final path2 = '$tmp/file2';
+      File(path1).writeAsStringSync('Hello World');
+
+      expect(
+        () => fileSystem.same(path1, path2),
+        throwsA(
+          isA<PathNotFoundException>()
+              .having((e) => e.message, 'message', 'stat failed')
+              .having((e) => e.path, 'path', path2)
+              .having((e) => e.osError?.errorCode, 'errorCode', stdlibc.ENOENT),
+        ),
+      );
+    });
+
+    test('path1 and path2 same, do not exist', () {
+      final path1 = '$tmp/file1';
+      final path2 = '$tmp/file1';
+
+      expect(
+        () => fileSystem.same(path1, path2),
+        throwsA(
+          isA<PathNotFoundException>()
+              .having((e) => e.message, 'message', 'stat failed')
+              .having((e) => e.path, 'path', path1)
+              .having((e) => e.osError?.errorCode, 'errorCode', stdlibc.ENOENT),
+        ),
+      );
+    });
+
+    test('path1 is a broken symlink', () {
+      final path1 = '$tmp/file1';
+      final path2 = '$tmp/file2';
+      Link(path1).createSync('$tmp/file3');
+      File(path2).writeAsStringSync('Hello World');
+
+      expect(
+        () => fileSystem.same(path1, path2),
+        throwsA(
+          isA<PathNotFoundException>()
+              .having((e) => e.message, 'message', 'stat failed')
+              .having((e) => e.path, 'path', path1)
+              .having((e) => e.osError?.errorCode, 'errorCode', stdlibc.ENOENT),
+        ),
+      );
+    });
+
+    test('path2 is a broken symlink', () {
+      final path1 = '$tmp/file1';
+      final path2 = '$tmp/file2';
+      File(path1).writeAsStringSync('Hello World');
+      Link(path2).createSync('$tmp/file3');
+
+      expect(
+        () => fileSystem.same(path1, path2),
+        throwsA(
+          isA<PathNotFoundException>()
+              .having((e) => e.message, 'message', 'stat failed')
+              .having((e) => e.path, 'path', path2)
+              .having((e) => e.osError?.errorCode, 'errorCode', stdlibc.ENOENT),
+        ),
+      );
+    });
+
+    test('path1 and path2 same, broken symlinks', () {
+      final path1 = '$tmp/file1';
+      final path2 = '$tmp/file1';
+      Link(path1).createSync('$tmp/file3');
+
+      expect(
+        () => fileSystem.same(path1, path2),
+        throwsA(
+          isA<PathNotFoundException>()
+              .having((e) => e.message, 'message', 'stat failed')
+              .having((e) => e.path, 'path', path1)
+              .having((e) => e.osError?.errorCode, 'errorCode', stdlibc.ENOENT),
+        ),
+      );
+    });
+
+    test('different files, same content', () {
+      final path1 = '$tmp/file1';
+      final path2 = '$tmp/file2';
+      File(path1).writeAsStringSync('Hello World');
+      File(path2).writeAsStringSync('Hello World');
+
+      expect(fileSystem.same(path1, path2), isFalse);
+    });
+
+    test('same file, absolute and relative paths', () {
+      Directory.current = tmp;
+      final path1 = '$tmp/file1';
+      const path2 = 'file1';
+      File(path1).writeAsStringSync('Hello World');
+
+      expect(fileSystem.same(path1, path2), isTrue);
+    });
+
+    test('file path1, symlink path2', () {
+      final path1 = '$tmp/file1';
+      final path2 = '$tmp/file2';
+      File(path1).writeAsStringSync('Hello World');
+      Link(path2).createSync(path1);
+
+      expect(fileSystem.same(path1, path2), isTrue);
+    });
+
+    test('file symlink path1, symlink path2', () {
+      final path1 = '$tmp/file1';
+      final path2 = '$tmp/file2';
+      File('$tmp/file3').writeAsStringSync('Hello World');
+      Link(path1).createSync('$tmp/file3');
+      Link(path2).createSync('$tmp/file3');
+
+      expect(fileSystem.same(path1, path2), isTrue);
+    });
+
+    test('files through intermediate symlinks', () {
+      Directory('$tmp/subdir').createSync();
+      Link('$tmp/link-to-subdir').createSync('$tmp/subdir');
+      final path1 = '$tmp/subdir/file1';
+      final path2 = '$tmp/link-to-subdir/file1';
+      File(path1).writeAsStringSync('Hello World');
+
+      expect(fileSystem.same(path1, path2), isTrue);
+    });
+
+    test('different directories, same content', () {
+      final path1 = '$tmp/dir1';
+      final path2 = '$tmp/dir2';
+      Directory(path1).createSync();
+      Directory(path2).createSync();
+
+      expect(fileSystem.same(path1, path2), isFalse);
+    });
+
+    test('same directory, absolute and relative paths', () {
+      Directory.current = tmp;
+      final path1 = '$tmp/dir1';
+      const path2 = 'dir1';
+      Directory(path1).createSync();
+
+      expect(fileSystem.same(path1, path2), isTrue);
+    });
+
+    test('directory path1, symlink path2', () {
+      final path1 = '$tmp/dir1';
+      final path2 = '$tmp/dir2';
+      Directory(path1).createSync();
+      Link(path2).createSync(path1);
+
+      expect(fileSystem.same(path1, path2), isTrue);
+    });
+
+    test('directory symlink path1, symlink path2', () {
+      final path1 = '$tmp/dir1';
+      final path2 = '$tmp/dir2';
+      Directory('$tmp/dir3').createSync();
+      Link(path1).createSync('$tmp/dir3');
+      Link(path2).createSync('$tmp/dir3');
+
+      expect(fileSystem.same(path1, path2), isTrue);
+    });
+
+    test('directories through intermediate symlinks', () {
+      Directory('$tmp/subdir').createSync();
+      Link('$tmp/link-to-subdir').createSync('$tmp/subdir');
+      final path1 = '$tmp/subdir/dir1';
+      final path2 = '$tmp/link-to-subdir/dir1';
+      Directory(path1).createSync();
+
+      expect(fileSystem.same(path1, path2), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
- This is different than `dart:io`'s `identical` method because it resolves the final path component if it is a symlink

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
