### PR TITLE
initial commit of package:googleapis_firestore_v1

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,6 +12,10 @@
   - changed-files:
     - any-glob-to-any-file: 'pkgs/gcloud/**'
 
+'package:googleapis_firestore_v1':
+  - changed-files:
+    - any-glob-to-any-file: 'pkgs/googleapis_firestore_v1/**'
+
 'package:io_file':
   - changed-files:
     - any-glob-to-any-file: 'pkgs/io_file/**'

--- a/.github/workflows/googleapis_firestore_v1.yaml
+++ b/.github/workflows/googleapis_firestore_v1.yaml
@@ -1,0 +1,44 @@
+name: package:googleapis_firestore_v1
+
+permissions: read-all
+
+on:
+  # Run CI on pushes to the main branch, and on PRs against main.
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/googleapis_firestore_v1.yml'
+      - 'pkgs/googleapis_firestore_v1/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/googleapis_firestore_v1.yml'
+      - 'pkgs/googleapis_firestore_v1/**'
+  schedule:
+    - cron: '0 0 * * 0' # weekly
+
+defaults:
+  run:
+    working-directory: pkgs/googleapis_firestore_v1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [stable, dev]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - run: dart pub get
+
+      - run: dart analyze --fatal-infos
+
+      - run: dart format --output=none --set-exit-if-changed .
+        if: ${{ matrix.sdk == 'stable' }}
+
+      # - run: dart test

--- a/pkgs/googleapis_firestore_v1/.gitignore
+++ b/pkgs/googleapis_firestore_v1/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/pkgs/googleapis_firestore_v1/LICENSE
+++ b/pkgs/googleapis_firestore_v1/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2025, the Dart project authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pkgs/googleapis_firestore_v1/README.md
+++ b/pkgs/googleapis_firestore_v1/README.md
@@ -1,0 +1,32 @@
+An experimental gRPC client for the Cloud Firestore API.
+
+## About
+
+Cloud Firestore is a fast, fully managed, serverless, cloud-native NoSQL
+document database that simplifies storing, syncing, and querying data for
+your mobile, web, and IoT apps at global scale. Its client libraries provide
+live synchronization and offline support, while its security features and
+integrations with Firebase and Google Cloud Platform accelerate building
+truly serverless apps.
+
+See also:
+
+- https://firebase.google.com/docs/firestore
+- https://cloud.google.com/firestore/native/docs/apis
+
+This package is a generated gRPC client used to access the Firestore API.
+
+## Status: Experimental
+
+**NOTE**: This package is currently experimental and published under the
+[labs.dart.dev](https://dart.dev/dart-team-packages) pub publisher in order to
+solicit feedback. 
+
+For packages in the labs.dart.dev publisher we generally plan to either graduate
+the package into a supported publisher (dart.dev, tools.dart.dev) after a period
+of feedback and iteration, or discontinue the package. These packages have a
+much higher expected rate of API and breaking changes.
+
+Your feedback is valuable and will help us evolve this package. For general
+feedback, suggestions, and comments, please file an issue in the 
+[bug tracker](https://github.com/dart-lang/labs/issues).

--- a/pkgs/googleapis_firestore_v1/analysis_options.yaml
+++ b/pkgs/googleapis_firestore_v1/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/pkgs/googleapis_firestore_v1/pubspec.yaml
+++ b/pkgs/googleapis_firestore_v1/pubspec.yaml
@@ -1,0 +1,14 @@
+name: googleapis_firestore_v1
+description: A gRPC client for the Cloud Firestore API.
+version: 0.1.0
+repository: https://github.com/dart-lang/labs/tree/main/pkgs/googleapis_firestore_v1
+
+publish_to: none
+
+environment:
+  sdk: ^3.7.0
+
+#dependencies:
+
+dev_dependencies:
+  lints: ^6.0.0


### PR DESCRIPTION
- initial commit of package:googleapis_firestore_v1

This is an unsupported, experimental gRPC client to access the firestore API.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
