### PR TITLE
Add the ability to test a `FileSystem` without using `dart:io` explicitly 

### DIFF
--- a/pkgs/io_file/test/create_directory_test.dart
+++ b/pkgs/io_file/test/create_directory_test.dart
@@ -13,185 +13,194 @@ import 'package:test/test.dart';
 import 'package:win32/win32.dart' as win32;
 
 import 'errors.dart' as errors;
+import 'file_system_file_utils.dart' hide fileUtils;
 import 'test_utils.dart';
+
+void tests(FileUtils utils, FileSystem fs) {
+  late String tmp;
+  late String cwd;
+
+  setUp(() {
+    tmp = createTemp('createDirectory');
+    cwd = fs.currentDirectory;
+    fs.currentDirectory = tmp;
+  });
+
+  tearDown(() {
+    fs.currentDirectory = cwd;
+    deleteTemp(tmp);
+  });
+
+  test('success', () {
+    final path = '$tmp/dir';
+
+    fs.createDirectory(path);
+    expect(utils.isDirectory(path), isTrue);
+  });
+
+  test('absolute path, long directory name', () {
+    // On Windows:
+    // When using an API to create a directory, the specified path cannot be
+    // so long that you cannot append an 8.3 file name (that is, the directory
+    // name cannot exceed MAX_PATH minus 12).
+    final dirname = 'd' * (io.Platform.isWindows ? win32.MAX_PATH - 12 : 255);
+    final path = p.join(tmp, dirname);
+
+    fs.createDirectory(path);
+    expect(utils.isDirectory(path), isTrue);
+  });
+
+  test('absolute path, too long directory name', () {
+    final path = p.join(tmp, 'd' * 256);
+
+    expect(
+      () => fs.createDirectory(path),
+      throwsA(
+        isA<IOFileException>()
+            .having((e) => e.path1, 'path1', path)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows
+                  ? win32.ERROR_INVALID_NAME
+                  : errors.enametoolong,
+            ),
+      ),
+    );
+  });
+
+  test('relative path, long directory name', () {
+    // On Windows:
+    // When using an API to create a directory, the specified path cannot be
+    // so long that you cannot append an 8.3 file name (that is, the directory
+    // name cannot exceed MAX_PATH minus 12).
+    final path = 'd' * (io.Platform.isWindows ? win32.MAX_PATH - 12 : 255);
+    fs.createDirectory(path);
+
+    expect(utils.isDirectory(path), isTrue);
+  });
+
+  test('relative path, too long directory name', () {
+    final path = 'd' * 256;
+
+    expect(
+      () => fs.createDirectory(path),
+      throwsA(
+        isA<IOFileException>()
+            .having((e) => e.path1, 'path1', path)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows
+                  ? win32.ERROR_INVALID_NAME
+                  : errors.enametoolong,
+            ),
+      ),
+    );
+  });
+
+  test('create in non-existent directory', () {
+    final path = '$tmp/foo/dir';
+
+    expect(
+      () => fs.createDirectory(path),
+      throwsA(
+        isA<PathNotFoundException>()
+            .having((e) => e.path1, 'path', path)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows
+                  ? win32.ERROR_PATH_NOT_FOUND
+                  : errors.enoent,
+            ),
+      ),
+    );
+  });
+
+  test('create over existing directory', () {
+    final path = '$tmp/dir';
+    io.Directory(path).createSync();
+
+    expect(
+      () => fs.createDirectory(path),
+      throwsA(
+        isA<PathExistsException>()
+            .having((e) => e.path1, 'path1', path)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows
+                  ? win32.ERROR_ALREADY_EXISTS
+                  : errors.eexist,
+            ),
+      ),
+    );
+  });
+
+  test('create "."', () {
+    const path = '.';
+    expect(
+      () => fs.createDirectory(path),
+      throwsA(
+        isA<PathExistsException>()
+            .having((e) => e.path1, 'path1', path)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows
+                  ? win32.ERROR_ALREADY_EXISTS
+                  : errors.eexist,
+            ),
+      ),
+    );
+  });
+
+  test('create ".."', () {
+    const path = '..';
+    expect(
+      () => fs.createDirectory(path),
+      throwsA(
+        isA<PathExistsException>()
+            .having((e) => e.path1, 'path1', path)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows
+                  ? win32.ERROR_ALREADY_EXISTS
+                  : errors.eexist,
+            ),
+      ),
+    );
+  });
+
+  test('create over existing file', () {
+    final path = '$tmp/file';
+    io.File(path).createSync();
+
+    expect(
+      () => fs.createDirectory(path),
+      throwsA(
+        isA<PathExistsException>()
+            .having((e) => e.path1, 'path1', path)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows
+                  ? win32.ERROR_ALREADY_EXISTS
+                  : errors.eexist,
+            ),
+      ),
+    );
+  });
+}
 
 void main() {
   group('createDirectory', () {
-    late String tmp;
-    late String cwd;
-
-    setUp(() {
-      tmp = createTemp('createDirectory');
-      cwd = fileSystem.currentDirectory;
-      fileSystem.currentDirectory = tmp;
-    });
-
-    tearDown(() {
-      fileSystem.currentDirectory = cwd;
-      deleteTemp(tmp);
-    });
-
-    test('success', () {
-      final path = '$tmp/dir';
-
-      fileSystem.createDirectory(path);
-      expect(io.FileSystemEntity.isDirectorySync(path), isTrue);
-    });
-
-    test('absolute path, long directory name', () {
-      // On Windows:
-      // When using an API to create a directory, the specified path cannot be
-      // so long that you cannot append an 8.3 file name (that is, the directory
-      // name cannot exceed MAX_PATH minus 12).
-      final dirname = 'd' * (io.Platform.isWindows ? win32.MAX_PATH - 12 : 255);
-      final path = p.join(tmp, dirname);
-
-      fileSystem.createDirectory(path);
-      expect(io.FileSystemEntity.isDirectorySync(path), isTrue);
-    });
-
-    test('absolute path, too long directory name', () {
-      final path = p.join(tmp, 'd' * 256);
-
-      expect(
-        () => fileSystem.createDirectory(path),
-        throwsA(
-          isA<IOFileException>()
-              .having((e) => e.path1, 'path1', path)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows
-                    ? win32.ERROR_INVALID_NAME
-                    : errors.enametoolong,
-              ),
-        ),
-      );
-    });
-
-    test('relative path, long directory name', () {
-      // On Windows:
-      // When using an API to create a directory, the specified path cannot be
-      // so long that you cannot append an 8.3 file name (that is, the directory
-      // name cannot exceed MAX_PATH minus 12).
-      final path = 'd' * (io.Platform.isWindows ? win32.MAX_PATH - 12 : 255);
-      fileSystem.createDirectory(path);
-
-      expect(io.FileSystemEntity.isDirectorySync(path), isTrue);
-    });
-
-    test('relative path, too long directory name', () {
-      final path = 'd' * 256;
-
-      expect(
-        () => fileSystem.createDirectory(path),
-        throwsA(
-          isA<IOFileException>()
-              .having((e) => e.path1, 'path1', path)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows
-                    ? win32.ERROR_INVALID_NAME
-                    : errors.enametoolong,
-              ),
-        ),
-      );
-    });
-
-    test('create in non-existent directory', () {
-      final path = '$tmp/foo/dir';
-
-      expect(
-        () => fileSystem.createDirectory(path),
-        throwsA(
-          isA<PathNotFoundException>()
-              .having((e) => e.path1, 'path', path)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows
-                    ? win32.ERROR_PATH_NOT_FOUND
-                    : errors.enoent,
-              ),
-        ),
-      );
-    });
-
-    test('create over existing directory', () {
-      final path = '$tmp/dir';
-      io.Directory(path).createSync();
-
-      expect(
-        () => fileSystem.createDirectory(path),
-        throwsA(
-          isA<PathExistsException>()
-              .having((e) => e.path1, 'path1', path)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows
-                    ? win32.ERROR_ALREADY_EXISTS
-                    : errors.eexist,
-              ),
-        ),
-      );
-    });
-
-    test('create "."', () {
-      const path = '.';
-      expect(
-        () => fileSystem.createDirectory(path),
-        throwsA(
-          isA<PathExistsException>()
-              .having((e) => e.path1, 'path1', path)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows
-                    ? win32.ERROR_ALREADY_EXISTS
-                    : errors.eexist,
-              ),
-        ),
-      );
-    });
-
-    test('create ".."', () {
-      const path = '..';
-      expect(
-        () => fileSystem.createDirectory(path),
-        throwsA(
-          isA<PathExistsException>()
-              .having((e) => e.path1, 'path1', path)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows
-                    ? win32.ERROR_ALREADY_EXISTS
-                    : errors.eexist,
-              ),
-        ),
-      );
-    });
-
-    test('create over existing file', () {
-      final path = '$tmp/file';
-      io.File(path).createSync();
-
-      expect(
-        () => fileSystem.createDirectory(path),
-        throwsA(
-          isA<PathExistsException>()
-              .having((e) => e.path1, 'path1', path)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows
-                    ? win32.ERROR_ALREADY_EXISTS
-                    : errors.eexist,
-              ),
-        ),
-      );
-    });
+    group('dart:io verification', () => tests(fileUtils(), fileSystem));
+    group(
+      'self verification',
+      () => tests(FileSystemFileUtils(fileSystem), fileSystem),
+    );
   });
 }

--- a/pkgs/io_file/test/dart_io_file_utils.dart
+++ b/pkgs/io_file/test/dart_io_file_utils.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'test_utils.dart';
+
+/// File utilities implemented using `dart:io`.
+///
+/// Used to verify `package:io_file` behavior against an external reference.
+class DartIOFileUtils implements FileUtils {
+  @override
+  String createTestDirectory(String testName) =>
+      Directory.systemTemp.createTempSync(testName).absolute.path;
+
+  @override
+  void deleteDirectoryTree(String path) =>
+      Directory(path).deleteSync(recursive: true);
+
+  @override
+  bool isDirectory(String path) => FileSystemEntity.isDirectorySync(path);
+
+  @override
+  void createDirectory(String path) => Directory(path).createSync();
+
+  @override
+  void createTextFile(String path, String s) => File(path).writeAsStringSync(s);
+}
+
+FileUtils fileUtils() => DartIOFileUtils();

--- a/pkgs/io_file/test/file_system_file_utils.dart
+++ b/pkgs/io_file/test/file_system_file_utils.dart
@@ -1,0 +1,37 @@
+import 'package:io_file/io_file.dart';
+
+import 'test_utils.dart';
+
+/// File utilities implemented using [FileSystem].
+///
+/// Used to verify the behavior of mocks and other implementations that may not
+/// touch the platform file system.
+class FileSystemFileUtils implements FileUtils {
+  final FileSystem fs;
+
+  FileSystemFileUtils([FileSystem? fs]) : fs = fs ?? fileSystem;
+
+  @override
+  void createDirectory(String path) {
+    fs.createDirectory(path);
+  }
+
+  @override
+  String createTestDirectory(String testName) =>
+      fs.createTemporaryDirectory(prefix: testName);
+
+  @override
+  void createTextFile(String path, String s) {
+    fs.writeAsString(path, s);
+  }
+
+  @override
+  void deleteDirectoryTree(String path) {
+    fs.removeDirectoryTree(path);
+  }
+
+  @override
+  bool isDirectory(String path) => fs.metadata(path).isDirectory;
+}
+
+FileUtils fileUtils() => FileSystemFileUtils();

--- a/pkgs/io_file/test/test_utils.dart
+++ b/pkgs/io_file/test/test_utils.dart
@@ -6,6 +6,10 @@ import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
+export 'test_utils_self.dart'
+    if (dart.library.io) 'dart_io_file_utils.dart'
+    show fileUtils;
+
 String createTemp(String testName) =>
     Directory.systemTemp.createTempSync(testName).absolute.path;
 void deleteTemp(String path) => Directory(path).deleteSync(recursive: true);
@@ -17,4 +21,15 @@ Uint8List randomUint8List(int length, {int? seed}) {
     l[i] = random.nextInt(255);
   }
   return l;
+}
+
+abstract interface class FileUtils {
+  String createTestDirectory(String testName);
+  void deleteDirectoryTree(String path);
+
+  bool isDirectory(String path);
+
+  void createDirectory(String path);
+
+  void createTextFile(String path, String s);
 }


### PR DESCRIPTION
The idea is that a non-platform `FileSystem` implementation (e.g. in-memory, WebDAV, etc.) should be testable using only itself as a reference.

I only updated only test to show what the change would look like conceptually.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
