### PR TITLE
Further reduce tests' dependency on `dart:io`

### DIFF
--- a/pkgs/io_file/test/copy_file_test.dart
+++ b/pkgs/io_file/test/copy_file_test.dart
@@ -20,322 +20,323 @@ import 'package:win32/win32.dart' as win32;
 
 import 'errors.dart' as errors;
 import 'fifo.dart';
+import 'file_system_file_utils.dart' hide fileUtils;
 import 'test_utils.dart';
 
-void main() {
-  group('copyFile', () {
-    late String tmp;
-    late String cwd;
+void tests(FileUtils utils, FileSystem fs) {
+  late String tmp;
+  late String cwd;
 
-    setUp(() {
-      tmp = createTemp('copyFile');
-      cwd = fileSystem.currentDirectory;
-      fileSystem.currentDirectory = tmp;
-    });
+  setUp(() {
+    tmp = utils.createTestDirectory('createDirectory');
+    cwd = fs.currentDirectory;
+    fs.currentDirectory = tmp;
+  });
 
-    tearDown(() {
-      fileSystem.currentDirectory = cwd;
-      deleteTemp(tmp);
-    });
+  tearDown(() {
+    fs.currentDirectory = cwd;
+    utils.deleteDirectoryTree(tmp);
+  });
 
-    test('copy does not preserve source permissions', () {
-      final data = randomUint8List(1024);
-      final oldPath = '$tmp/file1';
-      final newPath = '$tmp/file2';
-      io.File(oldPath).writeAsBytesSync(data);
+  test('copy does not preserve source permissions', () {
+    final data = randomUint8List(1024);
+    final oldPath = '$tmp/file1';
+    final newPath = '$tmp/file2';
+    utils.createBinaryFile(oldPath, data);
 
-      // Give "other users" write permissions.
-      using((arena) {
-        // rw-rw-rw-
-        if (libc.chmod(oldPath.toNativeUtf8(allocator: arena).cast(), 438) ==
-            -1) {
-          assert(false, 'libc.errno: ${libc.errno}');
-        }
-        final metadata = fileSystem.metadata(oldPath);
-        assert((metadata as PosixMetadata).mode & libc.S_IWOTH != 0);
-      });
-
-      fileSystem.copyFile(oldPath, newPath);
-
-      // Ensure that "other users" do not have write permissions on the copied
-      // file.
-      final metadata = fileSystem.metadata(newPath);
-      expect((metadata as PosixMetadata).mode & libc.S_IWOTH, 0);
-    }, skip: io.Platform.isWindows);
-
-    test(
-      'copy does not preserve source file attributes',
-      () {
-        final data = randomUint8List(1024);
-        final oldPath = '$tmp/file1';
-        final newPath = '$tmp/file2';
-        io.File(oldPath).writeAsBytesSync(data);
-        (fileSystem as WindowsFileSystem).setMetadata(
-          oldPath,
-          isReadOnly: true,
-        );
-
-        fileSystem.copyFile(oldPath, newPath);
-
-        final metadata = fileSystem.metadata(newPath);
-        expect((metadata as WindowsMetadata).isReadOnly, isFalse);
-      },
-      skip: !io.Platform.isWindows,
-    );
-
-    test('copy file absolute path', () {
-      final data = randomUint8List(1024);
-      final oldPath = '$tmp/file1';
-      final newPath = '$tmp/file2';
-      io.File(oldPath).writeAsBytesSync(data);
-
-      fileSystem.copyFile(oldPath, newPath);
-
-      expect(io.File(newPath).readAsBytesSync(), data);
-    });
-
-    test('copy between absolute paths, long file names', () {
-      final data = randomUint8List(1024);
-      final oldPath = p.join(tmp, '1' * 255);
-      final newPath = p.join(tmp, '2' * 255);
-      io.File(oldPath).writeAsBytesSync(data);
-
-      fileSystem.copyFile(oldPath, newPath);
-
-      expect(io.File(newPath).readAsBytesSync(), data);
-    });
-
-    test('copy between relative path, long file names', () {
-      final data = randomUint8List(1024);
-      final oldPath = '1' * 255;
-      final newPath = '2' * 255;
-      io.File(oldPath).writeAsBytesSync(data);
-
-      fileSystem.copyFile(oldPath, newPath);
-
-      expect(io.File(newPath).readAsBytesSync(), data);
-    });
-
-    test('copy directory', () {
-      final oldPath = '$tmp/dir1';
-      final newPath = '$tmp/dir2';
-      io.Directory(oldPath).createSync();
-
-      expect(
-        () => fileSystem.copyFile(oldPath, newPath),
-        throwsA(
-          isA<IOFileException>()
-              .having((e) => e.path1, 'path1', oldPath)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows
-                    ? win32.ERROR_ACCESS_DENIED
-                    : errors.eisdir,
-              ),
-        ),
-      );
-    });
-
-    test('copy link', () {
-      final data = randomUint8List(1024);
-      final oldPath = '$tmp/link';
-      final linkedFile = '$tmp/file1';
-      final newPath = '$tmp/file2';
-      io.File(linkedFile).writeAsBytesSync(data);
-      io.Link(oldPath).createSync(linkedFile);
-
-      fileSystem.copyFile(oldPath, newPath);
-
-      expect(io.File(newPath).readAsBytesSync(), data);
-    });
-
-    test('copy file to existing file', () {
-      final data = randomUint8List(1024);
-      final oldPath = '$tmp/file1';
-      final newPath = '$tmp/file2';
-      io.File(oldPath).writeAsBytesSync(data);
-      io.File(newPath).writeAsStringSync('Hello World!');
-
-      expect(
-        () => fileSystem.copyFile(oldPath, newPath),
-        throwsA(
-          isA<PathExistsException>()
-              .having((e) => e.path1, 'path1', newPath)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows ? win32.ERROR_FILE_EXISTS : errors.eexist,
-              ),
-        ),
-      );
-    });
-
-    test('copy file to existing link', () {
-      final data = randomUint8List(1024);
-      final oldPath = '$tmp/file1';
-      final linkedFile = '$tmp/file2';
-      final newPath = '$tmp/link';
-      io.File(oldPath).writeAsBytesSync(data);
-      io.File(linkedFile).writeAsStringSync('Hello World');
-      io.Link(newPath).createSync(linkedFile);
-
-      expect(
-        () => fileSystem.copyFile(oldPath, newPath),
-        throwsA(
-          isA<PathExistsException>()
-              .having((e) => e.path1, 'path1', newPath)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows ? win32.ERROR_FILE_EXISTS : errors.eexist,
-              ),
-        ),
-      );
-    });
-
-    test('copy to existing directory', () {
-      final data = randomUint8List(1024);
-      final oldPath = '$tmp/file1';
-      final newPath = '$tmp/file2';
-      io.File(oldPath).writeAsBytesSync(data);
-      io.Directory(newPath).createSync();
-
-      expect(
-        () => fileSystem.copyFile(oldPath, newPath),
-        throwsA(
-          isA<IOFileException>()
-              .having((e) => e.path1, 'path1', newPath)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows
-                    ? win32.ERROR_ACCESS_DENIED
-                    : errors.eexist,
-              ),
-        ),
-      );
-    });
-
-    test('copy non-existent', () {
-      final oldPath = '$tmp/file1';
-      final newPath = '$tmp/file2';
-
-      expect(
-        () => fileSystem.copyFile(oldPath, newPath),
-        throwsA(
-          isA<PathNotFoundException>()
-              .having((e) => e.path1, 'path1', oldPath)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows
-                    ? win32.ERROR_FILE_NOT_FOUND
-                    : errors.enoent,
-              ),
-        ),
-      );
-    });
-
-    test('copy to non-existent directory', () {
-      final data = randomUint8List(1024);
-      final oldPath = '$tmp/file1';
-      final newPath = '$tmp/foo/file2';
-      io.File(oldPath).writeAsBytesSync(data);
-
-      expect(
-        () => fileSystem.copyFile(oldPath, newPath),
-        throwsA(
-          isA<PathNotFoundException>()
-              .having((e) => e.path1, 'path1', newPath)
-              .having(
-                (e) => e.errorCode,
-                'errorCode',
-                io.Platform.isWindows
-                    ? win32.ERROR_PATH_NOT_FOUND
-                    : errors.enoent,
-              ),
-        ),
-      );
-    });
-
-    group('fifo', () {
-      for (var i = 0; i <= 1024; ++i) {
-        test('Read small file: $i bytes', () async {
-          final data = randomUint8List(i);
-          final oldPath = '$tmp/file1';
-          final newPath = '$tmp/file2';
-          final fifo =
-              (await Fifo.create(oldPath))
-                ..write(data)
-                ..close();
-
-          fileSystem.copyFile(fifo.path, newPath);
-
-          expect(io.File(newPath).readAsBytesSync(), data);
-        });
+    // Give "other users" write permissions.
+    using((arena) {
+      // rw-rw-rw-
+      if (libc.chmod(oldPath.toNativeUtf8(allocator: arena).cast(), 438) ==
+          -1) {
+        assert(false, 'libc.errno: ${libc.errno}');
       }
+      final metadata = fileSystem.metadata(oldPath);
+      assert((metadata as PosixMetadata).mode & libc.S_IWOTH != 0);
+    });
 
-      test('many single byte reads', () async {
-        final data = randomUint8List(20);
+    fileSystem.copyFile(oldPath, newPath);
+
+    // Ensure that "other users" do not have write permissions on the copied
+    // file.
+    final metadata = fileSystem.metadata(newPath);
+    expect((metadata as PosixMetadata).mode & libc.S_IWOTH, 0);
+  }, skip: io.Platform.isWindows);
+
+  test('copy does not preserve source file attributes', () {
+    final data = randomUint8List(1024);
+    final oldPath = '$tmp/file1';
+    final newPath = '$tmp/file2';
+    utils.createBinaryFile(oldPath, data);
+    (fileSystem as WindowsFileSystem).setMetadata(oldPath, isReadOnly: true);
+
+    fileSystem.copyFile(oldPath, newPath);
+
+    final metadata = fileSystem.metadata(newPath);
+    expect((metadata as WindowsMetadata).isReadOnly, isFalse);
+  }, skip: !io.Platform.isWindows);
+
+  test('copy file absolute path', () {
+    final data = randomUint8List(1024);
+    final oldPath = '$tmp/file1';
+    final newPath = '$tmp/file2';
+    utils.createBinaryFile(oldPath, data);
+
+    fileSystem.copyFile(oldPath, newPath);
+
+    expect(io.File(newPath).readAsBytesSync(), data);
+  });
+
+  test('copy between absolute paths, long file names', () {
+    final data = randomUint8List(1024);
+    final oldPath = p.join(tmp, '1' * 255);
+    final newPath = p.join(tmp, '2' * 255);
+    utils.createBinaryFile(oldPath, data);
+
+    fileSystem.copyFile(oldPath, newPath);
+
+    expect(io.File(newPath).readAsBytesSync(), data);
+  });
+
+  test('copy between relative path, long file names', () {
+    final data = randomUint8List(1024);
+    final oldPath = '1' * 255;
+    final newPath = '2' * 255;
+    utils.createBinaryFile(oldPath, data);
+
+    fileSystem.copyFile(oldPath, newPath);
+
+    expect(io.File(newPath).readAsBytesSync(), data);
+  });
+
+  test('copy directory', () {
+    final oldPath = '$tmp/dir1';
+    final newPath = '$tmp/dir2';
+    io.Directory(oldPath).createSync();
+
+    expect(
+      () => fileSystem.copyFile(oldPath, newPath),
+      throwsA(
+        isA<IOFileException>()
+            .having((e) => e.path1, 'path1', oldPath)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows ? win32.ERROR_ACCESS_DENIED : errors.eisdir,
+            ),
+      ),
+    );
+  });
+
+  test('copy link', () {
+    final data = randomUint8List(1024);
+    final oldPath = '$tmp/link';
+    final linkedFile = '$tmp/file1';
+    final newPath = '$tmp/file2';
+    utils.createBinaryFile(linkedFile, data);
+    io.Link(oldPath).createSync(linkedFile);
+
+    fileSystem.copyFile(oldPath, newPath);
+
+    expect(io.File(newPath).readAsBytesSync(), data);
+  });
+
+  test('copy file to existing file', () {
+    final data = randomUint8List(1024);
+    final oldPath = '$tmp/file1';
+    final newPath = '$tmp/file2';
+    utils
+      ..createBinaryFile(oldPath, data)
+      ..createTextFile(newPath, 'Hello World!');
+
+    expect(
+      () => fileSystem.copyFile(oldPath, newPath),
+      throwsA(
+        isA<PathExistsException>()
+            .having((e) => e.path1, 'path1', newPath)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows ? win32.ERROR_FILE_EXISTS : errors.eexist,
+            ),
+      ),
+    );
+  });
+
+  test('copy file to existing link', () {
+    final data = randomUint8List(1024);
+    final oldPath = '$tmp/file1';
+    final linkedFile = '$tmp/file2';
+    final newPath = '$tmp/link';
+    utils
+      ..createBinaryFile(oldPath, data)
+      ..createTextFile(linkedFile, 'Hello World!');
+    io.Link(newPath).createSync(linkedFile);
+
+    expect(
+      () => fileSystem.copyFile(oldPath, newPath),
+      throwsA(
+        isA<PathExistsException>()
+            .having((e) => e.path1, 'path1', newPath)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows ? win32.ERROR_FILE_EXISTS : errors.eexist,
+            ),
+      ),
+    );
+  });
+
+  test('copy to existing directory', () {
+    final data = randomUint8List(1024);
+    final oldPath = '$tmp/file1';
+    final newPath = '$tmp/file2';
+    utils
+      ..createBinaryFile(oldPath, data)
+      ..createDirectory(newPath);
+
+    expect(
+      () => fileSystem.copyFile(oldPath, newPath),
+      throwsA(
+        isA<IOFileException>()
+            .having((e) => e.path1, 'path1', newPath)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows ? win32.ERROR_ACCESS_DENIED : errors.eexist,
+            ),
+      ),
+    );
+  });
+
+  test('copy non-existent', () {
+    final oldPath = '$tmp/file1';
+    final newPath = '$tmp/file2';
+
+    expect(
+      () => fileSystem.copyFile(oldPath, newPath),
+      throwsA(
+        isA<PathNotFoundException>()
+            .having((e) => e.path1, 'path1', oldPath)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows
+                  ? win32.ERROR_FILE_NOT_FOUND
+                  : errors.enoent,
+            ),
+      ),
+    );
+  });
+
+  test('copy to non-existent directory', () {
+    final data = randomUint8List(1024);
+    final oldPath = '$tmp/file1';
+    final newPath = '$tmp/foo/file2';
+    utils.createBinaryFile(oldPath, data);
+
+    expect(
+      () => fileSystem.copyFile(oldPath, newPath),
+      throwsA(
+        isA<PathNotFoundException>()
+            .having((e) => e.path1, 'path1', newPath)
+            .having(
+              (e) => e.errorCode,
+              'errorCode',
+              io.Platform.isWindows
+                  ? win32.ERROR_PATH_NOT_FOUND
+                  : errors.enoent,
+            ),
+      ),
+    );
+  });
+
+  group('fifo', () {
+    for (var i = 0; i <= 1024; ++i) {
+      test('Read small file: $i bytes', () async {
+        final data = randomUint8List(i);
         final oldPath = '$tmp/file1';
         final newPath = '$tmp/file2';
-        final fifo = await Fifo.create(oldPath);
-        for (var byte in data) {
-          fifo
-            ..write(Uint8List(1)..[0] = byte)
-            ..delay(const Duration(milliseconds: 10));
-        }
-        fifo.close();
+        final fifo =
+            (await Fifo.create(oldPath))
+              ..write(data)
+              ..close();
 
         fileSystem.copyFile(fifo.path, newPath);
 
-        expect(io.File(newPath).readAsBytesSync(), data);
+        expect(utils.readBinaryFile(newPath), data);
       });
+    }
 
-      for (var i = blockSize - 2; i <= blockSize + 2; ++i) {
-        test('Read close to `blockSize`: $i bytes', () async {
-          final data = randomUint8List(i);
-          final oldPath = '$tmp/file1';
-          final newPath = '$tmp/file2';
-          final fifo =
-              (await Fifo.create(oldPath))
-                ..write(data)
-                ..close();
-
-          fileSystem.copyFile(fifo.path, newPath);
-
-          expect(io.File(newPath).readAsBytesSync(), data);
-        });
+    test('many single byte reads', () async {
+      final data = randomUint8List(20);
+      final oldPath = '$tmp/file1';
+      final newPath = '$tmp/file2';
+      final fifo = await Fifo.create(oldPath);
+      for (var byte in data) {
+        fifo
+          ..write(Uint8List(1)..[0] = byte)
+          ..delay(const Duration(milliseconds: 10));
       }
+      fifo.close();
+
+      fileSystem.copyFile(fifo.path, newPath);
+
+      expect(utils.readBinaryFile(newPath), data);
     });
 
-    group('regular files', () {
-      for (var i = 0; i <= 1024; ++i) {
-        test('copyFile small file: $i bytes', () {
-          final data = randomUint8List(i);
-          final oldPath = '$tmp/file1';
-          final newPath = '$tmp/file2';
-          io.File(oldPath).writeAsBytesSync(data);
+    for (var i = blockSize - 2; i <= blockSize + 2; ++i) {
+      test('Read close to `blockSize`: $i bytes', () async {
+        final data = randomUint8List(i);
+        final oldPath = '$tmp/file1';
+        final newPath = '$tmp/file2';
+        final fifo =
+            (await Fifo.create(oldPath))
+              ..write(data)
+              ..close();
 
-          fileSystem.copyFile(oldPath, newPath);
+        fileSystem.copyFile(fifo.path, newPath);
 
-          expect(io.File(newPath).readAsBytesSync(), data);
-        });
-      }
+        expect(utils.readBinaryFile(newPath), data);
+      });
+    }
+  });
 
-      for (var i = blockSize - 2; i <= blockSize + 2; ++i) {
-        test('copyFile close to `blockSize`: $i bytes', () {
-          final data = randomUint8List(i);
-          final oldPath = '$tmp/file1';
-          final newPath = '$tmp/file2';
-          io.File(oldPath).writeAsBytesSync(data);
+  group('regular files', () {
+    for (var i = 0; i <= 1024; ++i) {
+      test('copyFile small file: $i bytes', () {
+        final data = randomUint8List(i);
+        final oldPath = '$tmp/file1';
+        final newPath = '$tmp/file2';
+        io.File(oldPath).writeAsBytesSync(data);
 
-          fileSystem.copyFile(oldPath, newPath);
+        fileSystem.copyFile(oldPath, newPath);
 
-          expect(io.File(newPath).readAsBytesSync(), data);
-        });
-      }
-    });
+        expect(utils.readBinaryFile(newPath), data);
+      });
+    }
+
+    for (var i = blockSize - 2; i <= blockSize + 2; ++i) {
+      test('copyFile close to `blockSize`: $i bytes', () {
+        final data = randomUint8List(i);
+        final oldPath = '$tmp/file1';
+        final newPath = '$tmp/file2';
+        io.File(oldPath).writeAsBytesSync(data);
+
+        fileSystem.copyFile(oldPath, newPath);
+
+        expect(utils.readBinaryFile(newPath), data);
+      });
+    }
+  });
+}
+
+void main() {
+  group('copyFile', () {
+    group('dart:io verification', () => tests(fileUtils(), fileSystem));
+    group(
+      'self verification',
+      () => tests(FileSystemFileUtils(fileSystem), fileSystem),
+    );
   });
 }

--- a/pkgs/io_file/test/copy_file_test.dart
+++ b/pkgs/io_file/test/copy_file_test.dart
@@ -69,7 +69,7 @@ void tests(FileUtils utils, FileSystem fs) {
     final newPath = '$tmp/file2';
     utils.createBinaryFile(oldPath, data);
     (fileSystem as WindowsFileSystem).setMetadata(oldPath, isReadOnly: true);
-    tearDown(
+    addTearDown(
       () => (fileSystem as WindowsFileSystem).setMetadata(
         oldPath,
         isReadOnly: false,

--- a/pkgs/io_file/test/copy_file_test.dart
+++ b/pkgs/io_file/test/copy_file_test.dart
@@ -69,6 +69,12 @@ void tests(FileUtils utils, FileSystem fs) {
     final newPath = '$tmp/file2';
     utils.createBinaryFile(oldPath, data);
     (fileSystem as WindowsFileSystem).setMetadata(oldPath, isReadOnly: true);
+    tearDown(
+      () => (fileSystem as WindowsFileSystem).setMetadata(
+        oldPath,
+        isReadOnly: false,
+      ),
+    );
 
     fileSystem.copyFile(oldPath, newPath);
 

--- a/pkgs/io_file/test/copy_file_test.dart
+++ b/pkgs/io_file/test/copy_file_test.dart
@@ -69,9 +69,7 @@ void tests(FileUtils utils, FileSystem fs) {
     final newPath = '$tmp/file2';
     utils.createBinaryFile(oldPath, data);
     (fs as WindowsFileSystem).setMetadata(oldPath, isReadOnly: true);
-    addTearDown(
-      () => (fs as WindowsFileSystem).setMetadata(oldPath, isReadOnly: false),
-    );
+    addTearDown(() => fs.setMetadata(oldPath, isReadOnly: false));
 
     fs.copyFile(oldPath, newPath);
 

--- a/pkgs/io_file/test/create_directory_test.dart
+++ b/pkgs/io_file/test/create_directory_test.dart
@@ -21,14 +21,14 @@ void tests(FileUtils utils, FileSystem fs) {
   late String cwd;
 
   setUp(() {
-    tmp = createTemp('createDirectory');
+    tmp = utils.createTestDirectory('createDirectory');
     cwd = fs.currentDirectory;
     fs.currentDirectory = tmp;
   });
 
   tearDown(() {
     fs.currentDirectory = cwd;
-    deleteTemp(tmp);
+    utils.deleteDirectoryTree(tmp);
   });
 
   test('success', () {

--- a/pkgs/io_file/test/create_temporary_directory_test.dart
+++ b/pkgs/io_file/test/create_temporary_directory_test.dart
@@ -32,60 +32,60 @@ void tests(FileUtils utils, FileSystem fs) {
   });
 
   test('no arguments', () {
-    final tmp1 = fileSystem.createTemporaryDirectory();
+    final tmp1 = fs.createTemporaryDirectory();
     addTearDown(() => utils.deleteDirectory(tmp1));
-    final tmp2 = fileSystem.createTemporaryDirectory();
+    final tmp2 = fs.createTemporaryDirectory();
     addTearDown(() => utils.deleteDirectory(tmp2));
 
-    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(fs.same(tmp1, tmp2), isFalse);
     expect(utils.isDirectory(tmp1), isTrue);
     expect(utils.isDirectory(tmp2), isTrue);
   });
 
   test('prefix', () {
-    final tmp1 = fileSystem.createTemporaryDirectory(prefix: 'myprefix');
+    final tmp1 = fs.createTemporaryDirectory(prefix: 'myprefix');
     addTearDown(() => utils.deleteDirectory(tmp1));
-    final tmp2 = fileSystem.createTemporaryDirectory(prefix: 'myprefix');
+    final tmp2 = fs.createTemporaryDirectory(prefix: 'myprefix');
     addTearDown(() => utils.deleteDirectory(tmp2));
 
     expect(tmp1, contains('myprefix'));
     expect(tmp2, contains('myprefix'));
-    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(fs.same(tmp1, tmp2), isFalse);
     expect(utils.isDirectory(tmp1), isTrue);
     expect(utils.isDirectory(tmp2), isTrue);
   });
 
   test('prefix is empty string', () {
-    final tmp1 = fileSystem.createTemporaryDirectory(prefix: '');
+    final tmp1 = fs.createTemporaryDirectory(prefix: '');
     addTearDown(() => utils.deleteDirectory(tmp1));
-    final tmp2 = fileSystem.createTemporaryDirectory(prefix: '');
+    final tmp2 = fs.createTemporaryDirectory(prefix: '');
     addTearDown(() => utils.deleteDirectory(tmp2));
 
-    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(fs.same(tmp1, tmp2), isFalse);
     expect(utils.isDirectory(tmp1), isTrue);
     expect(utils.isDirectory(tmp2), isTrue);
   });
 
   test('prefix contains XXXXXX', () {
-    final tmp1 = fileSystem.createTemporaryDirectory(prefix: 'myprefix-XXXXXX');
+    final tmp1 = fs.createTemporaryDirectory(prefix: 'myprefix-XXXXXX');
     addTearDown(() => utils.deleteDirectory(tmp1));
-    final tmp2 = fileSystem.createTemporaryDirectory(prefix: 'myprefix-XXXXXX');
+    final tmp2 = fs.createTemporaryDirectory(prefix: 'myprefix-XXXXXX');
     addTearDown(() => utils.deleteDirectory(tmp2));
 
     expect(tmp1, contains('myprefix-'));
     expect(tmp2, contains('myprefix-'));
-    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(fs.same(tmp1, tmp2), isFalse);
     expect(utils.isDirectory(tmp1), isTrue);
     expect(utils.isDirectory(tmp2), isTrue);
   });
 
   test('parent', () {
-    final tmp1 = fileSystem.createTemporaryDirectory(parent: tmp);
-    final tmp2 = fileSystem.createTemporaryDirectory(parent: tmp);
+    final tmp1 = fs.createTemporaryDirectory(parent: tmp);
+    final tmp2 = fs.createTemporaryDirectory(parent: tmp);
 
     expect(tmp1, startsWith(tmp));
     expect(tmp2, startsWith(tmp));
-    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(fs.same(tmp1, tmp2), isFalse);
     expect(utils.isDirectory(tmp1), isTrue);
     expect(utils.isDirectory(tmp2), isTrue);
   });
@@ -99,32 +99,32 @@ void tests(FileUtils utils, FileSystem fs) {
     final parent = p.join(tmp, dirname);
     utils.createDirectory(parent);
 
-    final tmp1 = fileSystem.createTemporaryDirectory(parent: parent);
-    final tmp2 = fileSystem.createTemporaryDirectory(parent: parent);
+    final tmp1 = fs.createTemporaryDirectory(parent: parent);
+    final tmp2 = fs.createTemporaryDirectory(parent: parent);
 
     expect(tmp1, startsWith(tmp));
     expect(tmp2, startsWith(tmp));
-    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(fs.same(tmp1, tmp2), isFalse);
     expect(utils.isDirectory(tmp1), isTrue);
     expect(utils.isDirectory(tmp2), isTrue);
   });
 
   test('parent is empty string', () {
-    final tmp1 = fileSystem.createTemporaryDirectory(parent: '');
+    final tmp1 = fs.createTemporaryDirectory(parent: '');
     addTearDown(() => utils.deleteDirectory(tmp1));
-    final tmp2 = fileSystem.createTemporaryDirectory(parent: '');
+    final tmp2 = fs.createTemporaryDirectory(parent: '');
     addTearDown(() => utils.deleteDirectory(tmp2));
 
     expect(p.isRelative(tmp1), isTrue);
     expect(p.isRelative(tmp2), isTrue);
-    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(fs.same(tmp1, tmp2), isFalse);
     expect(utils.isDirectory(tmp1), isTrue);
     expect(utils.isDirectory(tmp2), isTrue);
   });
 
   test('parent does not exist', () {
     expect(
-      () => fileSystem.createTemporaryDirectory(parent: '/foo/bar/baz'),
+      () => fs.createTemporaryDirectory(parent: '/foo/bar/baz'),
       throwsA(
         isA<PathNotFoundException>().having(
           (e) => e.errorCode,
@@ -139,7 +139,7 @@ void tests(FileUtils utils, FileSystem fs) {
     final subdir1 = '$tmp/dir1';
     utils.createDirectory(subdir1);
 
-    final tmp1 = fileSystem.createTemporaryDirectory(
+    final tmp1 = fs.createTemporaryDirectory(
       parent: subdir1,
       prefix: '$subdir1/file',
     );
@@ -154,7 +154,7 @@ void tests(FileUtils utils, FileSystem fs) {
       ..createDirectory(subdir1)
       ..createDirectory(subdir2);
 
-    final tmp1 = fileSystem.createTemporaryDirectory(
+    final tmp1 = fs.createTemporaryDirectory(
       parent: subdir1,
       prefix: '$subdir2/file',
     );
@@ -164,7 +164,7 @@ void tests(FileUtils utils, FileSystem fs) {
 
   test('prefix is non-existant path inside temp directory', () {
     expect(
-      () => fileSystem.createTemporaryDirectory(prefix: 'subdir/file'),
+      () => fs.createTemporaryDirectory(prefix: 'subdir/file'),
       throwsA(
         isA<PathNotFoundException>().having(
           (e) => e.errorCode,
@@ -179,10 +179,7 @@ void tests(FileUtils utils, FileSystem fs) {
     final subdir1 = '$tmp/dir1';
     utils.createDirectory(subdir1);
 
-    final tmp1 = fileSystem.createTemporaryDirectory(
-      parent: tmp,
-      prefix: 'dir1/file',
-    );
+    final tmp1 = fs.createTemporaryDirectory(parent: tmp, prefix: 'dir1/file');
     expect(p.canonicalize(tmp1), startsWith(p.canonicalize(subdir1)));
     expect(utils.isDirectory(tmp1), isTrue);
   });

--- a/pkgs/io_file/test/create_temporary_directory_test.dart
+++ b/pkgs/io_file/test/create_temporary_directory_test.dart
@@ -13,181 +13,187 @@ import 'package:test/test.dart';
 import 'package:win32/win32.dart' as win32;
 
 import 'errors.dart' as errors;
+import 'file_system_file_utils.dart' hide fileUtils;
 import 'test_utils.dart';
+
+void tests(FileUtils utils, FileSystem fs) {
+  late String tmp;
+  late String cwd;
+
+  setUp(() {
+    tmp = utils.createTestDirectory('createTemporaryDirectory');
+    cwd = fs.currentDirectory;
+    fs.currentDirectory = tmp;
+  });
+
+  tearDown(() {
+    fs.currentDirectory = cwd;
+    utils.deleteDirectoryTree(tmp);
+  });
+
+  test('no arguments', () {
+    final tmp1 = fileSystem.createTemporaryDirectory();
+    addTearDown(() => utils.deleteDirectory(tmp1));
+    final tmp2 = fileSystem.createTemporaryDirectory();
+    addTearDown(() => utils.deleteDirectory(tmp2));
+
+    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(utils.isDirectory(tmp1), isTrue);
+    expect(utils.isDirectory(tmp2), isTrue);
+  });
+
+  test('prefix', () {
+    final tmp1 = fileSystem.createTemporaryDirectory(prefix: 'myprefix');
+    addTearDown(() => utils.deleteDirectory(tmp1));
+    final tmp2 = fileSystem.createTemporaryDirectory(prefix: 'myprefix');
+    addTearDown(() => utils.deleteDirectory(tmp2));
+
+    expect(tmp1, contains('myprefix'));
+    expect(tmp2, contains('myprefix'));
+    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(utils.isDirectory(tmp1), isTrue);
+    expect(utils.isDirectory(tmp2), isTrue);
+  });
+
+  test('prefix is empty string', () {
+    final tmp1 = fileSystem.createTemporaryDirectory(prefix: '');
+    addTearDown(() => utils.deleteDirectory(tmp1));
+    final tmp2 = fileSystem.createTemporaryDirectory(prefix: '');
+    addTearDown(() => utils.deleteDirectory(tmp2));
+
+    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(utils.isDirectory(tmp1), isTrue);
+    expect(utils.isDirectory(tmp2), isTrue);
+  });
+
+  test('prefix contains XXXXXX', () {
+    final tmp1 = fileSystem.createTemporaryDirectory(prefix: 'myprefix-XXXXXX');
+    addTearDown(() => utils.deleteDirectory(tmp1));
+    final tmp2 = fileSystem.createTemporaryDirectory(prefix: 'myprefix-XXXXXX');
+    addTearDown(() => utils.deleteDirectory(tmp2));
+
+    expect(tmp1, contains('myprefix-'));
+    expect(tmp2, contains('myprefix-'));
+    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(utils.isDirectory(tmp1), isTrue);
+    expect(utils.isDirectory(tmp2), isTrue);
+  });
+
+  test('parent', () {
+    final tmp1 = fileSystem.createTemporaryDirectory(parent: tmp);
+    final tmp2 = fileSystem.createTemporaryDirectory(parent: tmp);
+
+    expect(tmp1, startsWith(tmp));
+    expect(tmp2, startsWith(tmp));
+    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(utils.isDirectory(tmp1), isTrue);
+    expect(utils.isDirectory(tmp2), isTrue);
+  });
+
+  test('parent has a long directory name', () {
+    // On Windows:
+    // When using an API to create a directory, the specified path cannot be
+    // so long that you cannot append an 8.3 file name (that is, the directory
+    // name cannot exceed MAX_PATH minus 12).
+    final dirname = 'd' * (io.Platform.isWindows ? win32.MAX_PATH - 12 : 255);
+    final parent = p.join(tmp, dirname);
+    utils.createDirectory(parent);
+
+    final tmp1 = fileSystem.createTemporaryDirectory(parent: parent);
+    final tmp2 = fileSystem.createTemporaryDirectory(parent: parent);
+
+    expect(tmp1, startsWith(tmp));
+    expect(tmp2, startsWith(tmp));
+    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(utils.isDirectory(tmp1), isTrue);
+    expect(utils.isDirectory(tmp2), isTrue);
+  });
+
+  test('parent is empty string', () {
+    final tmp1 = fileSystem.createTemporaryDirectory(parent: '');
+    addTearDown(() => utils.deleteDirectory(tmp1));
+    final tmp2 = fileSystem.createTemporaryDirectory(parent: '');
+    addTearDown(() => utils.deleteDirectory(tmp2));
+
+    expect(p.isRelative(tmp1), isTrue);
+    expect(p.isRelative(tmp2), isTrue);
+    expect(fileSystem.same(tmp1, tmp2), isFalse);
+    expect(utils.isDirectory(tmp1), isTrue);
+    expect(utils.isDirectory(tmp2), isTrue);
+  });
+
+  test('parent does not exist', () {
+    expect(
+      () => fileSystem.createTemporaryDirectory(parent: '/foo/bar/baz'),
+      throwsA(
+        isA<PathNotFoundException>().having(
+          (e) => e.errorCode,
+          'errorCode',
+          io.Platform.isWindows ? win32.ERROR_PATH_NOT_FOUND : errors.enoent,
+        ),
+      ),
+    );
+  });
+
+  test('prefix is absolute path inside of parent', () {
+    final subdir1 = '$tmp/dir1';
+    utils.createDirectory(subdir1);
+
+    final tmp1 = fileSystem.createTemporaryDirectory(
+      parent: subdir1,
+      prefix: '$subdir1/file',
+    );
+
+    expect(tmp1, startsWith(subdir1));
+  });
+
+  test('prefix is absolute path outside of parent', () {
+    final subdir1 = '$tmp/dir1';
+    final subdir2 = '$tmp/dir2';
+    utils
+      ..createDirectory(subdir1)
+      ..createDirectory(subdir2);
+
+    final tmp1 = fileSystem.createTemporaryDirectory(
+      parent: subdir1,
+      prefix: '$subdir2/file',
+    );
+
+    expect(tmp1, startsWith(subdir2));
+  });
+
+  test('prefix is non-existant path inside temp directory', () {
+    expect(
+      () => fileSystem.createTemporaryDirectory(prefix: 'subdir/file'),
+      throwsA(
+        isA<PathNotFoundException>().having(
+          (e) => e.errorCode,
+          'errorCode',
+          io.Platform.isWindows ? win32.ERROR_PATH_NOT_FOUND : errors.enoent,
+        ),
+      ),
+    );
+  });
+
+  test('prefix is existant path inside temp directory', () {
+    final subdir1 = '$tmp/dir1';
+    utils.createDirectory(subdir1);
+
+    final tmp1 = fileSystem.createTemporaryDirectory(
+      parent: tmp,
+      prefix: 'dir1/file',
+    );
+    expect(p.canonicalize(tmp1), startsWith(p.canonicalize(subdir1)));
+    expect(utils.isDirectory(tmp1), isTrue);
+  });
+}
 
 void main() {
   group('createTemporaryDirectory', () {
-    late String tmp;
-    late String cwd;
-
-    setUp(() {
-      tmp = createTemp('createTemporaryDirectory');
-      cwd = fileSystem.currentDirectory;
-      fileSystem.currentDirectory = tmp;
-    });
-
-    tearDown(() {
-      fileSystem.currentDirectory = cwd;
-      deleteTemp(tmp);
-    });
-
-    test('no arguments', () {
-      final tmp1 = fileSystem.createTemporaryDirectory();
-      addTearDown(() => io.Directory(tmp1).deleteSync());
-      final tmp2 = fileSystem.createTemporaryDirectory();
-      addTearDown(() => io.Directory(tmp2).deleteSync());
-
-      expect(fileSystem.same(tmp1, tmp2), isFalse);
-      expect(io.Directory(tmp1).existsSync(), isTrue);
-      expect(io.Directory(tmp2).existsSync(), isTrue);
-    });
-
-    test('prefix', () {
-      final tmp1 = fileSystem.createTemporaryDirectory(prefix: 'myprefix');
-      addTearDown(() => io.Directory(tmp1).deleteSync());
-      final tmp2 = fileSystem.createTemporaryDirectory(prefix: 'myprefix');
-      addTearDown(() => io.Directory(tmp2).deleteSync());
-
-      expect(tmp1, contains('myprefix'));
-      expect(tmp2, contains('myprefix'));
-      expect(fileSystem.same(tmp1, tmp2), isFalse);
-      expect(io.Directory(tmp1).existsSync(), isTrue);
-      expect(io.Directory(tmp2).existsSync(), isTrue);
-    });
-
-    test('prefix is empty string', () {
-      final tmp1 = fileSystem.createTemporaryDirectory(prefix: '');
-      addTearDown(() => io.Directory(tmp1).deleteSync());
-      final tmp2 = fileSystem.createTemporaryDirectory(prefix: '');
-      addTearDown(() => io.Directory(tmp2).deleteSync());
-
-      expect(fileSystem.same(tmp1, tmp2), isFalse);
-      expect(io.Directory(tmp1).existsSync(), isTrue);
-      expect(io.Directory(tmp2).existsSync(), isTrue);
-    });
-
-    test('prefix contains XXXXXX', () {
-      final tmp1 = fileSystem.createTemporaryDirectory(
-        prefix: 'myprefix-XXXXXX',
-      );
-      addTearDown(() => io.Directory(tmp1).deleteSync());
-      final tmp2 = fileSystem.createTemporaryDirectory(
-        prefix: 'myprefix-XXXXXX',
-      );
-      addTearDown(() => io.Directory(tmp2).deleteSync());
-
-      expect(tmp1, contains('myprefix-'));
-      expect(tmp2, contains('myprefix-'));
-      expect(fileSystem.same(tmp1, tmp2), isFalse);
-      expect(io.Directory(tmp1).existsSync(), isTrue);
-      expect(io.Directory(tmp2).existsSync(), isTrue);
-    });
-
-    test('parent', () {
-      final tmp1 = fileSystem.createTemporaryDirectory(parent: tmp);
-      final tmp2 = fileSystem.createTemporaryDirectory(parent: tmp);
-
-      expect(tmp1, startsWith(tmp));
-      expect(tmp2, startsWith(tmp));
-      expect(fileSystem.same(tmp1, tmp2), isFalse);
-      expect(io.Directory(tmp1).existsSync(), isTrue);
-      expect(io.Directory(tmp2).existsSync(), isTrue);
-    });
-
-    test('parent has a long directory name', () {
-      // On Windows:
-      // When using an API to create a directory, the specified path cannot be
-      // so long that you cannot append an 8.3 file name (that is, the directory
-      // name cannot exceed MAX_PATH minus 12).
-      final dirname = 'd' * (io.Platform.isWindows ? win32.MAX_PATH - 12 : 255);
-      final parent = p.join(tmp, dirname);
-      io.Directory(parent).createSync();
-
-      final tmp1 = fileSystem.createTemporaryDirectory(parent: parent);
-      final tmp2 = fileSystem.createTemporaryDirectory(parent: parent);
-
-      expect(tmp1, startsWith(tmp));
-      expect(tmp2, startsWith(tmp));
-      expect(fileSystem.same(tmp1, tmp2), isFalse);
-      expect(io.Directory(tmp1).existsSync(), isTrue);
-      expect(io.Directory(tmp2).existsSync(), isTrue);
-    });
-
-    test('parent is empty string', () {
-      final tmp1 = fileSystem.createTemporaryDirectory(parent: '');
-      addTearDown(() => io.Directory(tmp1).deleteSync());
-      final tmp2 = fileSystem.createTemporaryDirectory(parent: '');
-      addTearDown(() => io.Directory(tmp2).deleteSync());
-
-      expect(p.isRelative(tmp1), isTrue);
-      expect(p.isRelative(tmp2), isTrue);
-      expect(fileSystem.same(tmp1, tmp2), isFalse);
-      expect(io.Directory(tmp1).existsSync(), isTrue);
-      expect(io.Directory(tmp2).existsSync(), isTrue);
-    });
-
-    test('parent does not exist', () {
-      expect(
-        () => fileSystem.createTemporaryDirectory(parent: '/foo/bar/baz'),
-        throwsA(
-          isA<PathNotFoundException>().having(
-            (e) => e.errorCode,
-            'errorCode',
-            io.Platform.isWindows ? win32.ERROR_PATH_NOT_FOUND : errors.enoent,
-          ),
-        ),
-      );
-    });
-
-    test('prefix is absolute path inside of parent', () {
-      final subdir1 = '$tmp/dir1';
-      io.Directory(subdir1).createSync();
-
-      final tmp1 = fileSystem.createTemporaryDirectory(
-        parent: subdir1,
-        prefix: '$subdir1/file',
-      );
-
-      expect(tmp1, startsWith(subdir1));
-    });
-
-    test('prefix is absolute path outside of parent', () {
-      final subdir1 = '$tmp/dir1';
-      final subdir2 = '$tmp/dir2';
-      io.Directory(subdir1).createSync();
-      io.Directory(subdir2).createSync();
-
-      final tmp1 = fileSystem.createTemporaryDirectory(
-        parent: subdir1,
-        prefix: '$subdir2/file',
-      );
-
-      expect(tmp1, startsWith(subdir2));
-    });
-
-    test('prefix is non-existant path inside temp directory', () {
-      expect(
-        () => fileSystem.createTemporaryDirectory(prefix: 'subdir/file'),
-        throwsA(
-          isA<PathNotFoundException>().having(
-            (e) => e.errorCode,
-            'errorCode',
-            io.Platform.isWindows ? win32.ERROR_PATH_NOT_FOUND : errors.enoent,
-          ),
-        ),
-      );
-    });
-
-    test('prefix is existant path inside temp directory', () {
-      final subdir1 = '$tmp/dir1';
-      io.Directory(subdir1).createSync();
-
-      final tmp1 = fileSystem.createTemporaryDirectory(
-        parent: tmp,
-        prefix: 'dir1/file',
-      );
-      expect(p.canonicalize(tmp1), startsWith(p.canonicalize(subdir1)));
-      expect(io.Directory(tmp1).existsSync(), isTrue);
-    });
+    group('dart:io verification', () => tests(fileUtils(), fileSystem));
+    group(
+      'self verification',
+      () => tests(FileSystemFileUtils(fileSystem), fileSystem),
+    );
   });
 }

--- a/pkgs/io_file/test/current_directory_test.dart
+++ b/pkgs/io_file/test/current_directory_test.dart
@@ -32,19 +32,19 @@ void tests(FileUtils utils, FileSystem fs) {
   test('absolute path', () {
     final path = '$tmp/dir';
     utils.createDirectory(path);
-    fileSystem.currentDirectory = path;
+    fs.currentDirectory = path;
 
     expect(
-      fileSystem.same(fileSystem.currentDirectory, path),
+      fs.same(fs.currentDirectory, path),
       isTrue,
       reason:
-          '${fileSystem.currentDirectory} is a diffent directory than'
+          '${fs.currentDirectory} is a diffent directory than'
           '$path',
     );
     expect(
-      p.isAbsolute(fileSystem.currentDirectory),
+      p.isAbsolute(fs.currentDirectory),
       isTrue,
-      reason: '${fileSystem.currentDirectory} is not absolute',
+      reason: '${fs.currentDirectory} is not absolute',
     );
   });
 
@@ -52,10 +52,10 @@ void tests(FileUtils utils, FileSystem fs) {
     // On Windows, limited to MAX_PATH (260) characters.
     final path = p.join(tmp, 'a' * 200, 'b' * 200);
     utils.createDirectory(path);
-    final oldCurrentDirectory = fileSystem.currentDirectory;
+    final oldCurrentDirectory = fs.currentDirectory;
 
     expect(
-      () => fileSystem.currentDirectory = path,
+      () => fs.currentDirectory = path,
       throwsA(
         isA<IOFileException>()
             .having((e) => e.path1, 'path1', path)
@@ -66,26 +66,26 @@ void tests(FileUtils utils, FileSystem fs) {
             ),
       ),
     );
-    expect(fileSystem.currentDirectory, oldCurrentDirectory);
+    expect(fs.currentDirectory, oldCurrentDirectory);
   }, skip: fs is! WindowsFileSystem);
 
   test('relative path', () {
     final path = '$tmp/dir';
     utils.createDirectory(path);
 
-    fileSystem.currentDirectory = 'dir';
+    fs.currentDirectory = 'dir';
 
     expect(
-      fileSystem.same(fileSystem.currentDirectory, path),
+      fs.same(fs.currentDirectory, path),
       isTrue,
       reason:
-          '${fileSystem.currentDirectory} is a diffent directory than '
+          '${fs.currentDirectory} is a diffent directory than '
           '$path',
     );
     expect(
-      p.isAbsolute(fileSystem.currentDirectory),
+      p.isAbsolute(fs.currentDirectory),
       isTrue,
-      reason: '${fileSystem.currentDirectory} is not absolute',
+      reason: '${fs.currentDirectory} is not absolute',
     );
   });
 }

--- a/pkgs/io_file/test/current_directory_test.dart
+++ b/pkgs/io_file/test/current_directory_test.dart
@@ -22,12 +22,12 @@ void tests(FileUtils utils, FileSystem fs) {
 
   setUp(() {
     tmp = utils.createTestDirectory('createDirectory');
-    cwd = fileSystem.currentDirectory;
-    fileSystem.currentDirectory = tmp;
+    cwd = fs.currentDirectory;
+    fs.currentDirectory = tmp;
   });
 
   tearDown(() {
-    fileSystem.currentDirectory = cwd;
+    fs.currentDirectory = cwd;
     utils.deleteDirectoryTree(tmp);
   });
 

--- a/pkgs/io_file/test/current_directory_test.dart
+++ b/pkgs/io_file/test/current_directory_test.dart
@@ -5,6 +5,8 @@
 @TestOn('vm')
 library;
 
+import 'dart:io' as io;
+
 import 'package:io_file/io_file.dart';
 import 'package:io_file/windows_file_system.dart';
 import 'package:path/path.dart' as p;
@@ -51,7 +53,7 @@ void tests(FileUtils utils, FileSystem fs) {
   test('absolute path, too long path', () {
     // On Windows, limited to MAX_PATH (260) characters.
     final path = p.join(tmp, 'a' * 200, 'b' * 200);
-    utils.createDirectory(path);
+    io.Directory(path).createSync(recursive: true);
     final oldCurrentDirectory = fs.currentDirectory;
 
     expect(

--- a/pkgs/io_file/test/current_directory_test.dart
+++ b/pkgs/io_file/test/current_directory_test.dart
@@ -5,9 +5,8 @@
 @TestOn('vm')
 library;
 
-import 'dart:io' as io;
-
 import 'package:io_file/io_file.dart';
+import 'package:io_file/windows_file_system.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:win32/win32.dart' as win32;
@@ -68,7 +67,7 @@ void tests(FileUtils utils, FileSystem fs) {
       ),
     );
     expect(fileSystem.currentDirectory, oldCurrentDirectory);
-  }, skip: !io.Platform.isWindows);
+  }, skip: fs is! WindowsFileSystem);
 
   test('relative path', () {
     final path = '$tmp/dir';

--- a/pkgs/io_file/test/dart_io_file_utils.dart
+++ b/pkgs/io_file/test/dart_io_file_utils.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'test_utils.dart';
 
@@ -6,6 +7,10 @@ import 'test_utils.dart';
 ///
 /// Used to verify `package:io_file` behavior against an external reference.
 class DartIOFileUtils implements FileUtils {
+  @override
+  void createBinaryFile(String path, Uint8List b) =>
+      File(path).writeAsBytesSync(b);
+
   @override
   String createTestDirectory(String testName) =>
       Directory.systemTemp.createTempSync(testName).absolute.path;
@@ -25,6 +30,9 @@ class DartIOFileUtils implements FileUtils {
 
   @override
   void createTextFile(String path, String s) => File(path).writeAsStringSync(s);
+
+  @override
+  Uint8List readBinaryFile(String path) => File(path).readAsBytesSync();
 }
 
 FileUtils fileUtils() => DartIOFileUtils();

--- a/pkgs/io_file/test/dart_io_file_utils.dart
+++ b/pkgs/io_file/test/dart_io_file_utils.dart
@@ -21,6 +21,9 @@ class DartIOFileUtils implements FileUtils {
   void createDirectory(String path) => Directory(path).createSync();
 
   @override
+  void deleteDirectory(String path) => Directory(path).deleteSync();
+
+  @override
   void createTextFile(String path, String s) => File(path).writeAsStringSync(s);
 }
 

--- a/pkgs/io_file/test/file_system_file_utils.dart
+++ b/pkgs/io_file/test/file_system_file_utils.dart
@@ -17,6 +17,11 @@ class FileSystemFileUtils implements FileUtils {
   }
 
   @override
+  void deleteDirectory(String path) {
+    // TODO: implement deleteDirectory
+  }
+
+  @override
   String createTestDirectory(String testName) =>
       fs.createTemporaryDirectory(prefix: testName);
 

--- a/pkgs/io_file/test/file_system_file_utils.dart
+++ b/pkgs/io_file/test/file_system_file_utils.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:io_file/io_file.dart';
 
 import 'test_utils.dart';
@@ -10,6 +12,9 @@ class FileSystemFileUtils implements FileUtils {
   final FileSystem fs;
 
   FileSystemFileUtils([FileSystem? fs]) : fs = fs ?? fileSystem;
+
+  @override
+  void createBinaryFile(String path, Uint8List b) => fs.writeAsBytes(path, b);
 
   @override
   void createDirectory(String path) {
@@ -37,6 +42,9 @@ class FileSystemFileUtils implements FileUtils {
 
   @override
   bool isDirectory(String path) => fs.metadata(path).isDirectory;
+
+  @override
+  Uint8List readBinaryFile(String path) => fs.readAsBytes(path);
 }
 
 FileUtils fileUtils() => FileSystemFileUtils();

--- a/pkgs/io_file/test/metadata_apple_test.dart
+++ b/pkgs/io_file/test/metadata_apple_test.dart
@@ -25,12 +25,12 @@ void tests(FileUtils utils, PosixFileSystem fs) {
 
   setUp(() {
     tmp = utils.createTestDirectory('createDirectory');
-    cwd = fileSystem.currentDirectory;
-    fileSystem.currentDirectory = tmp;
+    cwd = fs.currentDirectory;
+    fs.currentDirectory = tmp;
   });
 
   tearDown(() {
-    fileSystem.currentDirectory = cwd;
+    fs.currentDirectory = cwd;
     utils.deleteDirectoryTree(tmp);
   });
   test('false', () {

--- a/pkgs/io_file/test/metadata_apple_test.dart
+++ b/pkgs/io_file/test/metadata_apple_test.dart
@@ -6,54 +6,62 @@
 library;
 
 import 'dart:ffi';
-import 'dart:io';
 
 import 'package:ffi/ffi.dart';
+import 'package:io_file/io_file.dart';
 import 'package:io_file/src/vm_posix_file_system.dart';
 import 'package:stdlibc/stdlibc.dart' as stdlibc;
 import 'package:test/test.dart';
 
+import 'file_system_file_utils.dart' hide fileUtils;
 import 'test_utils.dart';
 
 @Native<Int Function(Pointer<Utf8>, Uint32)>(isLeaf: false)
 external int chflags(Pointer<Utf8> buf, int count);
 
+void tests(FileUtils utils, PosixFileSystem fs) {
+  late String tmp;
+  late String cwd;
+
+  setUp(() {
+    tmp = utils.createTestDirectory('createDirectory');
+    cwd = fileSystem.currentDirectory;
+    fileSystem.currentDirectory = tmp;
+  });
+
+  tearDown(() {
+    fileSystem.currentDirectory = cwd;
+    utils.deleteDirectoryTree(tmp);
+  });
+  test('false', () {
+    final path = '$tmp/file';
+    utils.createTextFile(path, 'Hello World');
+
+    final data = fs.metadata(path);
+    expect(data.isHidden, isFalse);
+  });
+  test('true', () {
+    final path = '$tmp/file';
+    utils.createTextFile(path, 'Hello World');
+    using((arena) {
+      chflags(path.toNativeUtf8(), stdlibc.UF_HIDDEN);
+    });
+
+    final data = fs.metadata(path);
+    expect(data.isHidden, isTrue);
+  });
+}
+
 void main() {
-  final posixFileSystem = PosixFileSystem();
-
   group('apple metadata', () {
-    late String tmp;
-    late String cwd;
-
-    setUp(() {
-      tmp = createTemp('createDirectory');
-      cwd = posixFileSystem.currentDirectory;
-      posixFileSystem.currentDirectory = tmp;
-    });
-
-    tearDown(() {
-      posixFileSystem.currentDirectory = cwd;
-      deleteTemp(tmp);
-    });
-
-    group('isHidden', () {
-      test('false', () {
-        final path = '$tmp/file';
-        File(path).writeAsStringSync('Hello World');
-
-        final data = posixFileSystem.metadata(path);
-        expect(data.isHidden, isFalse);
-      });
-      test('true', () {
-        final path = '$tmp/file';
-        File(path).writeAsStringSync('Hello World');
-        using((arena) {
-          chflags(path.toNativeUtf8(), stdlibc.UF_HIDDEN);
-        });
-
-        final data = posixFileSystem.metadata(path);
-        expect(data.isHidden, isTrue);
-      });
-    });
+    group(
+      'dart:io verification',
+      () => tests(fileUtils(), fileSystem as PosixFileSystem),
+    );
+    group(
+      'self verification',
+      () =>
+          tests(FileSystemFileUtils(fileSystem), fileSystem as PosixFileSystem),
+    );
   });
 }

--- a/pkgs/io_file/test/metadata_test.dart
+++ b/pkgs/io_file/test/metadata_test.dart
@@ -23,17 +23,17 @@ void tests(FileUtils utils, FileSystem fs) {
 
   setUp(() {
     tmp = utils.createTestDirectory('createDirectory');
-    cwd = fileSystem.currentDirectory;
-    fileSystem.currentDirectory = tmp;
+    cwd = fs.currentDirectory;
+    fs.currentDirectory = tmp;
   });
 
   tearDown(() {
-    fileSystem.currentDirectory = cwd;
+    fs.currentDirectory = cwd;
     utils.deleteDirectoryTree(tmp);
   });
   test('path does not exist', () {
     expect(
-      () => fileSystem.metadata('$tmp/file1'),
+      () => fs.metadata('$tmp/file1'),
       throwsA(
         isA<PathNotFoundException>().having(
           (e) => e.errorCode,
@@ -48,7 +48,7 @@ void tests(FileUtils utils, FileSystem fs) {
     final path = p.join(tmp, 'f' * 255);
     utils.createTextFile(path, 'Hello World');
 
-    final data = fileSystem.metadata(path);
+    final data = fs.metadata(path);
     expect(data.isFile, isTrue);
   });
 
@@ -56,13 +56,13 @@ void tests(FileUtils utils, FileSystem fs) {
     final path = 'f' * 255;
     utils.createTextFile(path, 'Hello World');
 
-    final data = fileSystem.metadata(path);
+    final data = fs.metadata(path);
     expect(data.isFile, isTrue);
   });
 
   group('file types', () {
     test('directory', () {
-      final data = fileSystem.metadata(tmp);
+      final data = fs.metadata(tmp);
       expect(data.isDirectory, isTrue);
       expect(data.isFile, isFalse);
       expect(data.isLink, isFalse);
@@ -71,7 +71,7 @@ void tests(FileUtils utils, FileSystem fs) {
     test(
       'tty',
       () {
-        final data = fileSystem.metadata('/dev/tty');
+        final data = fs.metadata('/dev/tty');
         expect(data.isDirectory, isFalse);
         expect(data.isFile, isFalse);
         expect(data.isLink, isFalse);
@@ -89,7 +89,7 @@ void tests(FileUtils utils, FileSystem fs) {
       final path = '$tmp/file1';
       utils.createTextFile(path, 'Hello World');
 
-      final data = fileSystem.metadata(path);
+      final data = fs.metadata(path);
       expect(data.isDirectory, isFalse);
       expect(data.isFile, isTrue);
       expect(data.isLink, isFalse);
@@ -98,7 +98,7 @@ void tests(FileUtils utils, FileSystem fs) {
     test('fifo', () async {
       final fifo = (await Fifo.create('$tmp/file'))..close();
 
-      final data = fileSystem.metadata(fifo.path);
+      final data = fs.metadata(fifo.path);
       expect(data.isDirectory, isFalse);
       expect(data.isFile, isFalse);
       expect(data.isLink, isFalse);
@@ -110,7 +110,7 @@ void tests(FileUtils utils, FileSystem fs) {
       try {
         // On Windows, opening the pipe consumes it. See:
         // https://github.com/dotnet/runtime/issues/69604
-        fileSystem.readAsBytes(fifo.path);
+        fs.readAsBytes(fifo.path);
       } catch (_) {}
     });
     test('file link', () {
@@ -118,7 +118,7 @@ void tests(FileUtils utils, FileSystem fs) {
       final path = '$tmp/link';
       io.Link(path).createSync('$tmp/file1');
 
-      final data = fileSystem.metadata(path);
+      final data = fs.metadata(path);
       expect(data.isDirectory, isFalse);
       expect(data.isFile, isFalse);
       expect(data.isLink, isTrue);
@@ -129,7 +129,7 @@ void tests(FileUtils utils, FileSystem fs) {
       final path = '$tmp/link';
       io.Link(path).createSync('$tmp/dir');
 
-      final data = fileSystem.metadata(path);
+      final data = fs.metadata(path);
       expect(data.isDirectory, isFalse);
       expect(data.isFile, isFalse);
       expect(data.isLink, isTrue);
@@ -146,7 +146,7 @@ void tests(FileUtils utils, FileSystem fs) {
       final path = '$tmp/file1';
       io.File(path).writeAsStringSync('Hello World!');
 
-      final data = fileSystem.metadata(path);
+      final data = fs.metadata(path);
       expect(data.isHidden, isNull);
     },
     skip:
@@ -159,14 +159,14 @@ void tests(FileUtils utils, FileSystem fs) {
       final path = '$tmp/file1';
       io.File(path).writeAsStringSync('');
 
-      final data = fileSystem.metadata(path);
+      final data = fs.metadata(path);
       expect(data.size, 0);
     });
     test('non-empty file', () {
       final path = '$tmp/file1';
       io.File(path).writeAsStringSync('Hello World!');
 
-      final data = fileSystem.metadata(path);
+      final data = fs.metadata(path);
       expect(data.size, 12);
     });
   });
@@ -178,7 +178,7 @@ void tests(FileUtils utils, FileSystem fs) {
         final path = '$tmp/file1';
         io.File(path).writeAsStringSync('');
 
-        final data = fileSystem.metadata(path);
+        final data = fs.metadata(path);
         expect(
           data.creation!.millisecondsSinceEpoch,
           closeTo(DateTime.now().millisecondsSinceEpoch, 5000),
@@ -196,7 +196,7 @@ void tests(FileUtils utils, FileSystem fs) {
       final path = '$tmp/file1';
       io.File(path).writeAsStringSync('Hello World!');
 
-      final data = fileSystem.metadata(path);
+      final data = fs.metadata(path);
       expect(
         data.modification.millisecondsSinceEpoch,
         closeTo(DateTime.now().millisecondsSinceEpoch, 5000),
@@ -205,11 +205,11 @@ void tests(FileUtils utils, FileSystem fs) {
     test('modified after creation', () async {
       final path = '$tmp/file1';
       io.File(path).writeAsStringSync('Hello World!');
-      final data1 = fileSystem.metadata(path);
+      final data1 = fs.metadata(path);
 
       await Future<void>.delayed(const Duration(milliseconds: 1000));
       io.File(path).writeAsStringSync('Hello World!');
-      final data2 = fileSystem.metadata(path);
+      final data2 = fs.metadata(path);
 
       expect(
         data2.modification.millisecondsSinceEpoch,

--- a/pkgs/io_file/test/metadata_test.dart
+++ b/pkgs/io_file/test/metadata_test.dart
@@ -14,209 +14,217 @@ import 'package:win32/win32.dart' as win32;
 
 import 'errors.dart' as errors;
 import 'fifo.dart';
+import 'file_system_file_utils.dart' hide fileUtils;
 import 'test_utils.dart';
 
-void main() {
-  group('metadata', () {
-    late String tmp;
-    late String cwd;
+void tests(FileUtils utils, FileSystem fs) {
+  late String tmp;
+  late String cwd;
 
-    setUp(() {
-      tmp = createTemp('createTemporaryDirectory');
-      cwd = fileSystem.currentDirectory;
-      fileSystem.currentDirectory = tmp;
-    });
+  setUp(() {
+    tmp = utils.createTestDirectory('createDirectory');
+    cwd = fileSystem.currentDirectory;
+    fileSystem.currentDirectory = tmp;
+  });
 
-    tearDown(() {
-      fileSystem.currentDirectory = cwd;
-      deleteTemp(tmp);
-    });
-
-    test('path does not exist', () {
-      expect(
-        () => fileSystem.metadata('$tmp/file1'),
-        throwsA(
-          isA<PathNotFoundException>().having(
-            (e) => e.errorCode,
-            'errorCode',
-            io.Platform.isWindows ? win32.ERROR_FILE_NOT_FOUND : errors.enoent,
-          ),
+  tearDown(() {
+    fileSystem.currentDirectory = cwd;
+    utils.deleteDirectoryTree(tmp);
+  });
+  test('path does not exist', () {
+    expect(
+      () => fileSystem.metadata('$tmp/file1'),
+      throwsA(
+        isA<PathNotFoundException>().having(
+          (e) => e.errorCode,
+          'errorCode',
+          io.Platform.isWindows ? win32.ERROR_FILE_NOT_FOUND : errors.enoent,
         ),
-      );
+      ),
+    );
+  });
+
+  test('absolute path, long name', () {
+    final path = p.join(tmp, 'f' * 255);
+    utils.createTextFile(path, 'Hello World');
+
+    final data = fileSystem.metadata(path);
+    expect(data.isFile, isTrue);
+  });
+
+  test('relative path, long name', () {
+    final path = 'f' * 255;
+    utils.createTextFile(path, 'Hello World');
+
+    final data = fileSystem.metadata(path);
+    expect(data.isFile, isTrue);
+  });
+
+  group('file types', () {
+    test('directory', () {
+      final data = fileSystem.metadata(tmp);
+      expect(data.isDirectory, isTrue);
+      expect(data.isFile, isFalse);
+      expect(data.isLink, isFalse);
+      expect(data.type, FileSystemType.directory);
     });
-
-    test('absolute path, long name', () {
-      final path = p.join(tmp, 'f' * 255);
-      io.File(path).writeAsStringSync('Hello World');
-
-      final data = fileSystem.metadata(path);
-      expect(data.isFile, isTrue);
-    });
-
-    test('relative path, long name', () {
-      final path = 'f' * 255;
-      io.File(path).writeAsStringSync('Hello World');
-
-      final data = fileSystem.metadata(path);
-      expect(data.isFile, isTrue);
-    });
-
-    group('file types', () {
-      test('directory', () {
-        final data = fileSystem.metadata(tmp);
-        expect(data.isDirectory, isTrue);
-        expect(data.isFile, isFalse);
-        expect(data.isLink, isFalse);
-        expect(data.type, FileSystemType.directory);
-      });
-      test(
-        'tty',
-        () {
-          final data = fileSystem.metadata('/dev/tty');
-          expect(data.isDirectory, isFalse);
-          expect(data.isFile, isFalse);
-          expect(data.isLink, isFalse);
-          expect(data.type, FileSystemType.character);
-        },
-        skip:
-            !(io.Platform.isAndroid |
-                    io.Platform.isIOS |
-                    io.Platform.isLinux |
-                    io.Platform.isIOS)
-                ? 'no /dev/tty'
-                : false,
-      );
-      test('file', () {
-        final path = '$tmp/file1';
-        io.File(path).writeAsStringSync('Hello World');
-
-        final data = fileSystem.metadata(path);
-        expect(data.isDirectory, isFalse);
-        expect(data.isFile, isTrue);
-        expect(data.isLink, isFalse);
-        expect(data.type, FileSystemType.file);
-      });
-      test('fifo', () async {
-        final fifo = (await Fifo.create('$tmp/file'))..close();
-
-        final data = fileSystem.metadata(fifo.path);
-        expect(data.isDirectory, isFalse);
-        expect(data.isFile, isFalse);
-        expect(data.isLink, isFalse);
-        expect(
-          data.type,
-          io.Platform.isWindows ? FileSystemType.unknown : FileSystemType.pipe,
-        );
-
-        try {
-          // On Windows, opening the pipe consumes it. See:
-          // https://github.com/dotnet/runtime/issues/69604
-          fileSystem.readAsBytes(fifo.path);
-        } catch (_) {}
-      });
-      test('file link', () {
-        io.File('$tmp/file1').writeAsStringSync('Hello World');
-        final path = '$tmp/link';
-        io.Link(path).createSync('$tmp/file1');
-
-        final data = fileSystem.metadata(path);
-        expect(data.isDirectory, isFalse);
-        expect(data.isFile, isFalse);
-        expect(data.isLink, isTrue);
-        expect(data.type, FileSystemType.link);
-      });
-      test('directory link', () {
-        io.Directory('$tmp/dir').createSync();
-        final path = '$tmp/link';
-        io.Link(path).createSync('$tmp/dir');
-
-        final data = fileSystem.metadata(path);
-        expect(data.isDirectory, isFalse);
-        expect(data.isFile, isFalse);
-        expect(data.isLink, isTrue);
-        expect(data.type, FileSystemType.link);
-      });
-    });
-
     test(
-      'isHidden',
+      'tty',
       () {
-        // Tested on iOS/macOS at: metadata_apple_test.dart
-        // Tested on Windows at: metadata_windows_test.dart
-
-        final path = '$tmp/file1';
-        io.File(path).writeAsStringSync('Hello World!');
-
-        final data = fileSystem.metadata(path);
-        expect(data.isHidden, isNull);
+        final data = fileSystem.metadata('/dev/tty');
+        expect(data.isDirectory, isFalse);
+        expect(data.isFile, isFalse);
+        expect(data.isLink, isFalse);
+        expect(data.type, FileSystemType.character);
       },
       skip:
-          (io.Platform.isIOS || io.Platform.isMacOS || io.Platform.isWindows)
-              ? 'does not support hidden file metadata'
+          !(io.Platform.isAndroid |
+                  io.Platform.isIOS |
+                  io.Platform.isLinux |
+                  io.Platform.isIOS)
+              ? 'no /dev/tty'
               : false,
     );
-    group('size', () {
-      test('empty file', () {
+    test('file', () {
+      final path = '$tmp/file1';
+      utils.createTextFile(path, 'Hello World');
+
+      final data = fileSystem.metadata(path);
+      expect(data.isDirectory, isFalse);
+      expect(data.isFile, isTrue);
+      expect(data.isLink, isFalse);
+      expect(data.type, FileSystemType.file);
+    });
+    test('fifo', () async {
+      final fifo = (await Fifo.create('$tmp/file'))..close();
+
+      final data = fileSystem.metadata(fifo.path);
+      expect(data.isDirectory, isFalse);
+      expect(data.isFile, isFalse);
+      expect(data.isLink, isFalse);
+      expect(
+        data.type,
+        io.Platform.isWindows ? FileSystemType.unknown : FileSystemType.pipe,
+      );
+
+      try {
+        // On Windows, opening the pipe consumes it. See:
+        // https://github.com/dotnet/runtime/issues/69604
+        fileSystem.readAsBytes(fifo.path);
+      } catch (_) {}
+    });
+    test('file link', () {
+      utils.createTextFile('$tmp/file1', 'Hello World');
+      final path = '$tmp/link';
+      io.Link(path).createSync('$tmp/file1');
+
+      final data = fileSystem.metadata(path);
+      expect(data.isDirectory, isFalse);
+      expect(data.isFile, isFalse);
+      expect(data.isLink, isTrue);
+      expect(data.type, FileSystemType.link);
+    });
+    test('directory link', () {
+      io.Directory('$tmp/dir').createSync();
+      final path = '$tmp/link';
+      io.Link(path).createSync('$tmp/dir');
+
+      final data = fileSystem.metadata(path);
+      expect(data.isDirectory, isFalse);
+      expect(data.isFile, isFalse);
+      expect(data.isLink, isTrue);
+      expect(data.type, FileSystemType.link);
+    });
+  });
+
+  test(
+    'isHidden',
+    () {
+      // Tested on iOS/macOS at: metadata_apple_test.dart
+      // Tested on Windows at: metadata_windows_test.dart
+
+      final path = '$tmp/file1';
+      io.File(path).writeAsStringSync('Hello World!');
+
+      final data = fileSystem.metadata(path);
+      expect(data.isHidden, isNull);
+    },
+    skip:
+        (io.Platform.isIOS || io.Platform.isMacOS || io.Platform.isWindows)
+            ? 'does not support hidden file metadata'
+            : false,
+  );
+  group('size', () {
+    test('empty file', () {
+      final path = '$tmp/file1';
+      io.File(path).writeAsStringSync('');
+
+      final data = fileSystem.metadata(path);
+      expect(data.size, 0);
+    });
+    test('non-empty file', () {
+      final path = '$tmp/file1';
+      io.File(path).writeAsStringSync('Hello World!');
+
+      final data = fileSystem.metadata(path);
+      expect(data.size, 12);
+    });
+  });
+
+  group(
+    'creation',
+    () {
+      test('newly created', () {
         final path = '$tmp/file1';
         io.File(path).writeAsStringSync('');
 
         final data = fileSystem.metadata(path);
-        expect(data.size, 0);
-      });
-      test('non-empty file', () {
-        final path = '$tmp/file1';
-        io.File(path).writeAsStringSync('Hello World!');
-
-        final data = fileSystem.metadata(path);
-        expect(data.size, 12);
-      });
-    });
-
-    group(
-      'creation',
-      () {
-        test('newly created', () {
-          final path = '$tmp/file1';
-          io.File(path).writeAsStringSync('');
-
-          final data = fileSystem.metadata(path);
-          expect(
-            data.creation!.millisecondsSinceEpoch,
-            closeTo(DateTime.now().millisecondsSinceEpoch, 5000),
-          );
-        });
-      },
-      skip:
-          !(io.Platform.isIOS || io.Platform.isMacOS || io.Platform.isWindows)
-              ? 'creation not supported'
-              : false,
-    );
-
-    group('modification', () {
-      test('newly created', () {
-        final path = '$tmp/file1';
-        io.File(path).writeAsStringSync('Hello World!');
-
-        final data = fileSystem.metadata(path);
         expect(
-          data.modification.millisecondsSinceEpoch,
+          data.creation!.millisecondsSinceEpoch,
           closeTo(DateTime.now().millisecondsSinceEpoch, 5000),
         );
       });
-      test('modified after creation', () async {
-        final path = '$tmp/file1';
-        io.File(path).writeAsStringSync('Hello World!');
-        final data1 = fileSystem.metadata(path);
+    },
+    skip:
+        !(io.Platform.isIOS || io.Platform.isMacOS || io.Platform.isWindows)
+            ? 'creation not supported'
+            : false,
+  );
 
-        await Future<void>.delayed(const Duration(milliseconds: 1000));
-        io.File(path).writeAsStringSync('Hello World!');
-        final data2 = fileSystem.metadata(path);
+  group('modification', () {
+    test('newly created', () {
+      final path = '$tmp/file1';
+      io.File(path).writeAsStringSync('Hello World!');
 
-        expect(
-          data2.modification.millisecondsSinceEpoch,
-          greaterThan(data1.modification.millisecondsSinceEpoch),
-        );
-      });
+      final data = fileSystem.metadata(path);
+      expect(
+        data.modification.millisecondsSinceEpoch,
+        closeTo(DateTime.now().millisecondsSinceEpoch, 5000),
+      );
     });
+    test('modified after creation', () async {
+      final path = '$tmp/file1';
+      io.File(path).writeAsStringSync('Hello World!');
+      final data1 = fileSystem.metadata(path);
+
+      await Future<void>.delayed(const Duration(milliseconds: 1000));
+      io.File(path).writeAsStringSync('Hello World!');
+      final data2 = fileSystem.metadata(path);
+
+      expect(
+        data2.modification.millisecondsSinceEpoch,
+        greaterThan(data1.modification.millisecondsSinceEpoch),
+      );
+    });
+  });
+}
+
+void main() {
+  group('metadata', () {
+    group('dart:io verification', () => tests(fileUtils(), fileSystem));
+    group(
+      'self verification',
+      () => tests(FileSystemFileUtils(fileSystem), fileSystem),
+    );
   });
 }

--- a/pkgs/io_file/test/metadata_windows_test.dart
+++ b/pkgs/io_file/test/metadata_windows_test.dart
@@ -11,218 +11,235 @@ import 'package:io_file/src/vm_windows_file_system.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
-import 'file_system_file_utils.dart' hide fileUtils;
 import 'test_utils.dart';
 
-void tests(FileUtils utils, WindowsFileSystem fileSystem) {
-  late String tmp;
-  late String cwd;
+void main() {
+  final windowsFileSystem = WindowsFileSystem();
 
-  setUp(() {
-    tmp = utils.createTestDirectory('createDirectory');
-    cwd = fileSystem.currentDirectory;
-    fileSystem.currentDirectory = tmp;
-  });
+  group('windows metadata', () {
+    late String tmp;
+    late String cwd;
 
-  tearDown(() {
-    fileSystem.currentDirectory = cwd;
-    utils.deleteDirectoryTree(tmp);
-  });
-
-  group('isReadOnly', () {
-    test('false', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-
-      final data = fileSystem.metadata(path);
-      expect(data.isReadOnly, isFalse);
+    setUp(() {
+      tmp = createTemp('createTemporaryDirectory');
+      cwd = windowsFileSystem.currentDirectory;
+      windowsFileSystem.currentDirectory = tmp;
     });
-    test('true', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      fileSystem.setMetadata(path, isReadOnly: true);
 
-      final data = fileSystem.metadata(path);
-      expect(data.isReadOnly, isTrue);
+    tearDown(() {
+      windowsFileSystem.currentDirectory = cwd;
+      deleteTemp(tmp);
     });
-  });
 
-  group('isHidden', () {
-    test('false', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
+    group('isReadOnly', () {
+      test('false', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
 
-      final data = fileSystem.metadata(path);
-      expect(data.isHidden, isFalse);
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isReadOnly, isFalse);
+      });
+      test('true', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        windowsFileSystem.setMetadata(path, isReadOnly: true);
+
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isReadOnly, isTrue);
+      });
     });
-    test('true', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      fileSystem.setMetadata(path, isHidden: true);
 
-      final data = fileSystem.metadata(path);
-      expect(data.isHidden, isTrue);
+    group('isHidden', () {
+      test('false', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isHidden, isFalse);
+      });
+      test('true', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        windowsFileSystem.setMetadata(path, isHidden: true);
+
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isHidden, isTrue);
+      });
     });
-  });
 
-  group('isSystem', () {
-    test('false', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
+    group('isSystem', () {
+      test('false', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
 
-      final data = fileSystem.metadata(path);
-      expect(data.isSystem, isFalse);
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isSystem, isFalse);
+      });
+      test('true', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        windowsFileSystem.setMetadata(path, isSystem: true);
+
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isSystem, isTrue);
+      });
     });
-    test('true', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      fileSystem.setMetadata(path, isSystem: true);
 
-      final data = fileSystem.metadata(path);
-      expect(data.isSystem, isTrue);
+    group('needsArchive', () {
+      test('false', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        windowsFileSystem.setMetadata(path, needsArchive: false);
+
+        final data = windowsFileSystem.metadata(path);
+        expect(data.needsArchive, isFalse);
+      });
+      test('true', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        windowsFileSystem.setMetadata(path, needsArchive: true);
+
+        final data = windowsFileSystem.metadata(path);
+        expect(data.needsArchive, isTrue);
+      });
     });
-  });
 
-  group('needsArchive', () {
-    test('false', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      fileSystem.setMetadata(path, needsArchive: false);
+    group('isTemporary', () {
+      test('false', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
 
-      final data = fileSystem.metadata(path);
-      expect(data.needsArchive, isFalse);
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isTemporary, isFalse);
+      });
+      test('true', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        windowsFileSystem.setMetadata(path, isTemporary: true);
+
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isTemporary, isTrue);
+      });
     });
-    test('true', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      fileSystem.setMetadata(path, needsArchive: true);
 
-      final data = fileSystem.metadata(path);
-      expect(data.needsArchive, isTrue);
+    group('isContentNotIndexed', () {
+      test('false', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        windowsFileSystem.setMetadata(path, isContentIndexed: false);
+
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isContentIndexed, isFalse);
+      });
+      test('true', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        windowsFileSystem.setMetadata(path, isContentIndexed: true);
+
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isContentIndexed, isTrue);
+      });
     });
-  });
 
-  group('isTemporary', () {
-    test('false', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
+    group('isOffline', () {
+      test('false', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
 
-      final data = fileSystem.metadata(path);
-      expect(data.isTemporary, isFalse);
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isOffline, isFalse);
+      });
+      test('true', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        windowsFileSystem.setMetadata(path, isOffline: true);
+
+        final data = windowsFileSystem.metadata(path);
+        expect(data.isOffline, isTrue);
+      });
     });
-    test('true', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      fileSystem.setMetadata(path, isTemporary: true);
 
-      final data = fileSystem.metadata(path);
-      expect(data.isTemporary, isTrue);
+    group('creation', () {
+      test('new file', () {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        final maxCreationTime = DateTime.now().millisecondsSinceEpoch;
+
+        final data = windowsFileSystem.metadata(path);
+        expect(
+          data.creation.millisecondsSinceEpoch,
+          // Creation time within 1 second.
+          inInclusiveRange(maxCreationTime - 1000, maxCreationTime),
+        );
+      });
     });
-  });
 
-  group('isContentNotIndexed', () {
-    test('false', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      fileSystem.setMetadata(path, isContentIndexed: false);
+    group('modificiation', () {
+      test('new file', () async {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        await Future<void>.delayed(const Duration(seconds: 1));
+        File(path).writeAsStringSync('How are you?');
+        final maxModificationTime = DateTime.now().millisecondsSinceEpoch;
 
-      final data = fileSystem.metadata(path);
-      expect(data.isContentIndexed, isFalse);
+        final data = windowsFileSystem.metadata(path);
+        expect(
+          data.modification.millisecondsSinceEpoch,
+          inInclusiveRange(
+            data.creation.millisecondsSinceEpoch + 1000,
+            maxModificationTime,
+          ),
+        );
+      });
     });
-    test('true', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      fileSystem.setMetadata(path, isContentIndexed: true);
 
-      final data = fileSystem.metadata(path);
-      expect(data.isContentIndexed, isTrue);
-    });
-  });
+    group('access', () {
+      test('new file', () async {
+        final path = '$tmp/file1';
+        File(path).writeAsStringSync('Hello World');
+        File(path).readAsBytesSync();
+        final maxAccessTime = DateTime.now().millisecondsSinceEpoch;
 
-  group('isOffline', () {
-    test('false', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-
-      final data = fileSystem.metadata(path);
-      expect(data.isOffline, isFalse);
-    });
-    test('true', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      fileSystem.setMetadata(path, isOffline: true);
-
-      final data = fileSystem.metadata(path);
-      expect(data.isOffline, isTrue);
-    });
-  });
-
-  group('creation', () {
-    test('new file', () {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      final maxCreationTime = DateTime.now().millisecondsSinceEpoch;
-
-      final data = fileSystem.metadata(path);
-      expect(
-        data.creation.millisecondsSinceEpoch,
-        // Creation time within 1 second.
-        inInclusiveRange(maxCreationTime - 1000, maxCreationTime),
-      );
-    });
-  });
-
-  group('modificiation', () {
-    test('new file', () async {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      await Future<void>.delayed(const Duration(seconds: 1));
-      File(path).writeAsStringSync('How are you?');
-      final maxModificationTime = DateTime.now().millisecondsSinceEpoch;
-
-      final data = fileSystem.metadata(path);
-      expect(
-        data.modification.millisecondsSinceEpoch,
-        inInclusiveRange(
-          data.creation.millisecondsSinceEpoch + 1000,
-          maxModificationTime,
-        ),
-      );
-    });
-  });
-
-  group('access', () {
-    test('new file', () async {
-      final path = '$tmp/file1';
-      File(path).writeAsStringSync('Hello World');
-      File(path).readAsBytesSync();
-      final maxAccessTime = DateTime.now().millisecondsSinceEpoch;
-
-      final data = fileSystem.metadata(path);
-      expect(
-        data.access.millisecondsSinceEpoch,
-        inInclusiveRange(data.creation.millisecondsSinceEpoch, maxAccessTime),
-      );
+        final data = windowsFileSystem.metadata(path);
+        expect(
+          data.access.millisecondsSinceEpoch,
+          inInclusiveRange(data.creation.millisecondsSinceEpoch, maxAccessTime),
+        );
+      });
     });
   });
 
   group('set metadata', () {
+    late String tmp;
+    late String cwd;
+
+    setUp(() {
+      tmp = createTemp('createTemporaryDirectory');
+      cwd = windowsFileSystem.currentDirectory;
+      windowsFileSystem.currentDirectory = tmp;
+    });
+
+    tearDown(() {
+      windowsFileSystem.currentDirectory = cwd;
+      deleteTemp(tmp);
+    });
+
     test('absolute path, long name', () {
       final path = p.join(tmp, 'f' * 255);
       File(path).writeAsStringSync('Hello World');
 
-      fileSystem.setMetadata(path, isReadOnly: true);
+      windowsFileSystem.setMetadata(path, isReadOnly: true);
 
-      expect(fileSystem.metadata(path).isReadOnly, isTrue);
+      expect(windowsFileSystem.metadata(path).isReadOnly, isTrue);
     });
 
     test('relative path, long name', () {
       final path = 'f' * 255;
       File(path).writeAsStringSync('Hello World');
 
-      fileSystem.setMetadata(path, isReadOnly: true);
+      windowsFileSystem.setMetadata(path, isReadOnly: true);
 
-      expect(fileSystem.metadata(path).isReadOnly, isTrue);
+      expect(windowsFileSystem.metadata(path).isReadOnly, isTrue);
     });
 
     for (var includeOriginalMetadata in [true, false]) {
@@ -234,7 +251,7 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
           setUp(() {
             path = '$tmp/file1';
             File(path).writeAsStringSync('Hello World');
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isReadOnly: true,
               isHidden: true,
@@ -244,24 +261,24 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
               isContentIndexed: true,
               isOffline: true,
             );
-            initialMetadata = fileSystem.metadata(path);
+            initialMetadata = windowsFileSystem.metadata(path);
           });
 
           test('set none', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
-            expect(fileSystem.metadata(path), initialMetadata);
+            expect(windowsFileSystem.metadata(path), initialMetadata);
           });
           test('unset isReadOnly', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isReadOnly: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isTrue);
@@ -272,13 +289,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
           });
 
           test('unset isHidden', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isHidden: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isTrue);
@@ -288,13 +305,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
             expect(data.isOffline, isTrue);
           });
           test('unset isSystem', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isSystem: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isFalse);
@@ -304,13 +321,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
             expect(data.isOffline, isTrue);
           });
           test('unset needsArchive', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               needsArchive: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isTrue);
@@ -320,13 +337,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
             expect(data.isOffline, isTrue);
           });
           test('unset isTemporary', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isTemporary: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isTrue);
@@ -336,13 +353,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
             expect(data.isOffline, isTrue);
           });
           test('unset isContentNotIndexed', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isContentIndexed: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isTrue);
@@ -352,13 +369,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
             expect(data.isOffline, isTrue);
           });
           test('unset isOffline', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isOffline: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isTrue);
@@ -376,7 +393,7 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
           setUp(() {
             path = '$tmp/file1';
             File(path).writeAsStringSync('Hello World');
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isReadOnly: false,
               isHidden: false,
@@ -386,24 +403,24 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
               isContentIndexed: false,
               isOffline: false,
             );
-            initialMetadata = fileSystem.metadata(path);
+            initialMetadata = windowsFileSystem.metadata(path);
           });
 
           test('set none', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
-            expect(fileSystem.metadata(path), initialMetadata);
+            expect(windowsFileSystem.metadata(path), initialMetadata);
           });
           test('set isReadOnly', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isReadOnly: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isFalse);
@@ -414,13 +431,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
           });
 
           test('set isHidden', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isHidden: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isFalse);
@@ -430,13 +447,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
             expect(data.isOffline, isFalse);
           });
           test('set isSystem', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isSystem: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isTrue);
@@ -446,13 +463,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
             expect(data.isOffline, isFalse);
           });
           test('set needsArchive', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               needsArchive: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isFalse);
@@ -462,13 +479,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
             expect(data.isOffline, isFalse);
           });
           test('set isTemporary', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isTemporary: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isFalse);
@@ -478,13 +495,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
             expect(data.isOffline, isFalse);
           });
           test('set isContentNotIndexed', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isContentIndexed: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isFalse);
@@ -494,13 +511,13 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
             expect(data.isOffline, isFalse);
           });
           test('set isOffline', () {
-            fileSystem.setMetadata(
+            windowsFileSystem.setMetadata(
               path,
               isOffline: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = fileSystem.metadata(path);
+            final data = windowsFileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isFalse);
@@ -512,16 +529,5 @@ void tests(FileUtils utils, WindowsFileSystem fileSystem) {
         });
       });
     }
-  });
-}
-
-void main() {
-  group('windows metadata', () {
-    final fileSystem = WindowsFileSystem();
-    group('dart:io verification', () => tests(fileUtils(), fileSystem));
-    group(
-      'self verification',
-      () => tests(FileSystemFileUtils(fileSystem), fileSystem),
-    );
   });
 }

--- a/pkgs/io_file/test/metadata_windows_test.dart
+++ b/pkgs/io_file/test/metadata_windows_test.dart
@@ -11,235 +11,218 @@ import 'package:io_file/src/vm_windows_file_system.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
+import 'file_system_file_utils.dart' hide fileUtils;
 import 'test_utils.dart';
 
-void main() {
-  final windowsFileSystem = WindowsFileSystem();
+void tests(FileUtils utils, WindowsFileSystem fileSystem) {
+  late String tmp;
+  late String cwd;
 
-  group('windows metadata', () {
-    late String tmp;
-    late String cwd;
+  setUp(() {
+    tmp = utils.createTestDirectory('createDirectory');
+    cwd = fileSystem.currentDirectory;
+    fileSystem.currentDirectory = tmp;
+  });
 
-    setUp(() {
-      tmp = createTemp('createTemporaryDirectory');
-      cwd = windowsFileSystem.currentDirectory;
-      windowsFileSystem.currentDirectory = tmp;
+  tearDown(() {
+    fileSystem.currentDirectory = cwd;
+    utils.deleteDirectoryTree(tmp);
+  });
+
+  group('isReadOnly', () {
+    test('false', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+
+      final data = fileSystem.metadata(path);
+      expect(data.isReadOnly, isFalse);
     });
+    test('true', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      fileSystem.setMetadata(path, isReadOnly: true);
 
-    tearDown(() {
-      windowsFileSystem.currentDirectory = cwd;
-      deleteTemp(tmp);
+      final data = fileSystem.metadata(path);
+      expect(data.isReadOnly, isTrue);
     });
+  });
 
-    group('isReadOnly', () {
-      test('false', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
+  group('isHidden', () {
+    test('false', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
 
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isReadOnly, isFalse);
-      });
-      test('true', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        windowsFileSystem.setMetadata(path, isReadOnly: true);
-
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isReadOnly, isTrue);
-      });
+      final data = fileSystem.metadata(path);
+      expect(data.isHidden, isFalse);
     });
+    test('true', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      fileSystem.setMetadata(path, isHidden: true);
 
-    group('isHidden', () {
-      test('false', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isHidden, isFalse);
-      });
-      test('true', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        windowsFileSystem.setMetadata(path, isHidden: true);
-
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isHidden, isTrue);
-      });
+      final data = fileSystem.metadata(path);
+      expect(data.isHidden, isTrue);
     });
+  });
 
-    group('isSystem', () {
-      test('false', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
+  group('isSystem', () {
+    test('false', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
 
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isSystem, isFalse);
-      });
-      test('true', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        windowsFileSystem.setMetadata(path, isSystem: true);
-
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isSystem, isTrue);
-      });
+      final data = fileSystem.metadata(path);
+      expect(data.isSystem, isFalse);
     });
+    test('true', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      fileSystem.setMetadata(path, isSystem: true);
 
-    group('needsArchive', () {
-      test('false', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        windowsFileSystem.setMetadata(path, needsArchive: false);
-
-        final data = windowsFileSystem.metadata(path);
-        expect(data.needsArchive, isFalse);
-      });
-      test('true', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        windowsFileSystem.setMetadata(path, needsArchive: true);
-
-        final data = windowsFileSystem.metadata(path);
-        expect(data.needsArchive, isTrue);
-      });
+      final data = fileSystem.metadata(path);
+      expect(data.isSystem, isTrue);
     });
+  });
 
-    group('isTemporary', () {
-      test('false', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
+  group('needsArchive', () {
+    test('false', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      fileSystem.setMetadata(path, needsArchive: false);
 
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isTemporary, isFalse);
-      });
-      test('true', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        windowsFileSystem.setMetadata(path, isTemporary: true);
-
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isTemporary, isTrue);
-      });
+      final data = fileSystem.metadata(path);
+      expect(data.needsArchive, isFalse);
     });
+    test('true', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      fileSystem.setMetadata(path, needsArchive: true);
 
-    group('isContentNotIndexed', () {
-      test('false', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        windowsFileSystem.setMetadata(path, isContentIndexed: false);
-
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isContentIndexed, isFalse);
-      });
-      test('true', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        windowsFileSystem.setMetadata(path, isContentIndexed: true);
-
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isContentIndexed, isTrue);
-      });
+      final data = fileSystem.metadata(path);
+      expect(data.needsArchive, isTrue);
     });
+  });
 
-    group('isOffline', () {
-      test('false', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
+  group('isTemporary', () {
+    test('false', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
 
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isOffline, isFalse);
-      });
-      test('true', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        windowsFileSystem.setMetadata(path, isOffline: true);
-
-        final data = windowsFileSystem.metadata(path);
-        expect(data.isOffline, isTrue);
-      });
+      final data = fileSystem.metadata(path);
+      expect(data.isTemporary, isFalse);
     });
+    test('true', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      fileSystem.setMetadata(path, isTemporary: true);
 
-    group('creation', () {
-      test('new file', () {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        final maxCreationTime = DateTime.now().millisecondsSinceEpoch;
-
-        final data = windowsFileSystem.metadata(path);
-        expect(
-          data.creation.millisecondsSinceEpoch,
-          // Creation time within 1 second.
-          inInclusiveRange(maxCreationTime - 1000, maxCreationTime),
-        );
-      });
+      final data = fileSystem.metadata(path);
+      expect(data.isTemporary, isTrue);
     });
+  });
 
-    group('modificiation', () {
-      test('new file', () async {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        await Future<void>.delayed(const Duration(seconds: 1));
-        File(path).writeAsStringSync('How are you?');
-        final maxModificationTime = DateTime.now().millisecondsSinceEpoch;
+  group('isContentNotIndexed', () {
+    test('false', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      fileSystem.setMetadata(path, isContentIndexed: false);
 
-        final data = windowsFileSystem.metadata(path);
-        expect(
-          data.modification.millisecondsSinceEpoch,
-          inInclusiveRange(
-            data.creation.millisecondsSinceEpoch + 1000,
-            maxModificationTime,
-          ),
-        );
-      });
+      final data = fileSystem.metadata(path);
+      expect(data.isContentIndexed, isFalse);
     });
+    test('true', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      fileSystem.setMetadata(path, isContentIndexed: true);
 
-    group('access', () {
-      test('new file', () async {
-        final path = '$tmp/file1';
-        File(path).writeAsStringSync('Hello World');
-        File(path).readAsBytesSync();
-        final maxAccessTime = DateTime.now().millisecondsSinceEpoch;
+      final data = fileSystem.metadata(path);
+      expect(data.isContentIndexed, isTrue);
+    });
+  });
 
-        final data = windowsFileSystem.metadata(path);
-        expect(
-          data.access.millisecondsSinceEpoch,
-          inInclusiveRange(data.creation.millisecondsSinceEpoch, maxAccessTime),
-        );
-      });
+  group('isOffline', () {
+    test('false', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+
+      final data = fileSystem.metadata(path);
+      expect(data.isOffline, isFalse);
+    });
+    test('true', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      fileSystem.setMetadata(path, isOffline: true);
+
+      final data = fileSystem.metadata(path);
+      expect(data.isOffline, isTrue);
+    });
+  });
+
+  group('creation', () {
+    test('new file', () {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      final maxCreationTime = DateTime.now().millisecondsSinceEpoch;
+
+      final data = fileSystem.metadata(path);
+      expect(
+        data.creation.millisecondsSinceEpoch,
+        // Creation time within 1 second.
+        inInclusiveRange(maxCreationTime - 1000, maxCreationTime),
+      );
+    });
+  });
+
+  group('modificiation', () {
+    test('new file', () async {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      await Future<void>.delayed(const Duration(seconds: 1));
+      File(path).writeAsStringSync('How are you?');
+      final maxModificationTime = DateTime.now().millisecondsSinceEpoch;
+
+      final data = fileSystem.metadata(path);
+      expect(
+        data.modification.millisecondsSinceEpoch,
+        inInclusiveRange(
+          data.creation.millisecondsSinceEpoch + 1000,
+          maxModificationTime,
+        ),
+      );
+    });
+  });
+
+  group('access', () {
+    test('new file', () async {
+      final path = '$tmp/file1';
+      File(path).writeAsStringSync('Hello World');
+      File(path).readAsBytesSync();
+      final maxAccessTime = DateTime.now().millisecondsSinceEpoch;
+
+      final data = fileSystem.metadata(path);
+      expect(
+        data.access.millisecondsSinceEpoch,
+        inInclusiveRange(data.creation.millisecondsSinceEpoch, maxAccessTime),
+      );
     });
   });
 
   group('set metadata', () {
-    late String tmp;
-    late String cwd;
-
-    setUp(() {
-      tmp = createTemp('createTemporaryDirectory');
-      cwd = windowsFileSystem.currentDirectory;
-      windowsFileSystem.currentDirectory = tmp;
-    });
-
-    tearDown(() {
-      windowsFileSystem.currentDirectory = cwd;
-      deleteTemp(tmp);
-    });
-
     test('absolute path, long name', () {
       final path = p.join(tmp, 'f' * 255);
       File(path).writeAsStringSync('Hello World');
 
-      windowsFileSystem.setMetadata(path, isReadOnly: true);
+      fileSystem.setMetadata(path, isReadOnly: true);
 
-      expect(windowsFileSystem.metadata(path).isReadOnly, isTrue);
+      expect(fileSystem.metadata(path).isReadOnly, isTrue);
     });
 
     test('relative path, long name', () {
       final path = 'f' * 255;
       File(path).writeAsStringSync('Hello World');
 
-      windowsFileSystem.setMetadata(path, isReadOnly: true);
+      fileSystem.setMetadata(path, isReadOnly: true);
 
-      expect(windowsFileSystem.metadata(path).isReadOnly, isTrue);
+      expect(fileSystem.metadata(path).isReadOnly, isTrue);
     });
 
     for (var includeOriginalMetadata in [true, false]) {
@@ -251,7 +234,7 @@ void main() {
           setUp(() {
             path = '$tmp/file1';
             File(path).writeAsStringSync('Hello World');
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isReadOnly: true,
               isHidden: true,
@@ -261,24 +244,24 @@ void main() {
               isContentIndexed: true,
               isOffline: true,
             );
-            initialMetadata = windowsFileSystem.metadata(path);
+            initialMetadata = fileSystem.metadata(path);
           });
 
           test('set none', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
-            expect(windowsFileSystem.metadata(path), initialMetadata);
+            expect(fileSystem.metadata(path), initialMetadata);
           });
           test('unset isReadOnly', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isReadOnly: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isTrue);
@@ -289,13 +272,13 @@ void main() {
           });
 
           test('unset isHidden', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isHidden: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isTrue);
@@ -305,13 +288,13 @@ void main() {
             expect(data.isOffline, isTrue);
           });
           test('unset isSystem', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isSystem: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isFalse);
@@ -321,13 +304,13 @@ void main() {
             expect(data.isOffline, isTrue);
           });
           test('unset needsArchive', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               needsArchive: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isTrue);
@@ -337,13 +320,13 @@ void main() {
             expect(data.isOffline, isTrue);
           });
           test('unset isTemporary', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isTemporary: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isTrue);
@@ -353,13 +336,13 @@ void main() {
             expect(data.isOffline, isTrue);
           });
           test('unset isContentNotIndexed', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isContentIndexed: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isTrue);
@@ -369,13 +352,13 @@ void main() {
             expect(data.isOffline, isTrue);
           });
           test('unset isOffline', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isOffline: false,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isTrue);
@@ -393,7 +376,7 @@ void main() {
           setUp(() {
             path = '$tmp/file1';
             File(path).writeAsStringSync('Hello World');
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isReadOnly: false,
               isHidden: false,
@@ -403,24 +386,24 @@ void main() {
               isContentIndexed: false,
               isOffline: false,
             );
-            initialMetadata = windowsFileSystem.metadata(path);
+            initialMetadata = fileSystem.metadata(path);
           });
 
           test('set none', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
-            expect(windowsFileSystem.metadata(path), initialMetadata);
+            expect(fileSystem.metadata(path), initialMetadata);
           });
           test('set isReadOnly', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isReadOnly: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isTrue);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isFalse);
@@ -431,13 +414,13 @@ void main() {
           });
 
           test('set isHidden', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isHidden: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isTrue);
             expect(data.isSystem, isFalse);
@@ -447,13 +430,13 @@ void main() {
             expect(data.isOffline, isFalse);
           });
           test('set isSystem', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isSystem: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isTrue);
@@ -463,13 +446,13 @@ void main() {
             expect(data.isOffline, isFalse);
           });
           test('set needsArchive', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               needsArchive: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isFalse);
@@ -479,13 +462,13 @@ void main() {
             expect(data.isOffline, isFalse);
           });
           test('set isTemporary', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isTemporary: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isFalse);
@@ -495,13 +478,13 @@ void main() {
             expect(data.isOffline, isFalse);
           });
           test('set isContentNotIndexed', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isContentIndexed: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isFalse);
@@ -511,13 +494,13 @@ void main() {
             expect(data.isOffline, isFalse);
           });
           test('set isOffline', () {
-            windowsFileSystem.setMetadata(
+            fileSystem.setMetadata(
               path,
               isOffline: true,
               original: includeOriginalMetadata ? initialMetadata : null,
             );
 
-            final data = windowsFileSystem.metadata(path);
+            final data = fileSystem.metadata(path);
             expect(data.isReadOnly, isFalse);
             expect(data.isHidden, isFalse);
             expect(data.isSystem, isFalse);
@@ -529,5 +512,16 @@ void main() {
         });
       });
     }
+  });
+}
+
+void main() {
+  group('windows metadata', () {
+    final fileSystem = WindowsFileSystem();
+    group('dart:io verification', () => tests(fileUtils(), fileSystem));
+    group(
+      'self verification',
+      () => tests(FileSystemFileUtils(fileSystem), fileSystem),
+    );
   });
 }

--- a/pkgs/io_file/test/test_utils.dart
+++ b/pkgs/io_file/test/test_utils.dart
@@ -30,6 +30,7 @@ abstract interface class FileUtils {
   bool isDirectory(String path);
 
   void createDirectory(String path);
+  void deleteDirectory(String path);
 
   void createTextFile(String path, String s);
 }

--- a/pkgs/io_file/test/test_utils.dart
+++ b/pkgs/io_file/test/test_utils.dart
@@ -33,4 +33,7 @@ abstract interface class FileUtils {
   void deleteDirectory(String path);
 
   void createTextFile(String path, String s);
+  void createBinaryFile(String path, Uint8List b);
+
+  Uint8List readBinaryFile(String path);
 }


### PR DESCRIPTION
This is a test-only change. There is still more work to do....

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
