### PR TITLE
Retry on test failure

### DIFF
--- a/pkgs/io_file/dart_test.yaml
+++ b/pkgs/io_file/dart_test.yaml
@@ -1,10 +1,6 @@
 concurrency: 1
 reporter: compact
 test-randomize-ordering-seed: random
-on_platform:
-  # TODO(brianquinlan): Remove retries when
-  # https://github.com/dart-lang/sdk/issues/38832 is fixed.
-  android || ios || linux || mac-os:
-    retry: 1
-  windows:
-    retry: 3
+# TODO(brianquinlan): Remove retries when
+# https://github.com/dart-lang/sdk/issues/38832 is fixed.
+retry: 1


### PR DESCRIPTION
This works around the fact that the VM does not preserve errno/GetLastError across API calls.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
