### PR TITLE
generate package:googleapis_firestore_v1 with http routing headers

### DIFF
--- a/pkgs/googleapis_firestore_v1/lib/google/firestore/v1/firestore.pbgrpc.dart
+++ b/pkgs/googleapis_firestore_v1/lib/google/firestore/v1/firestore.pbgrpc.dart
@@ -48,6 +48,24 @@ class FirestoreClient extends $grpc.Client {
     $0.GetDocumentRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasName()) {
+        final value = request.name;
+        final regexps = [_regexp0];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('name=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createUnaryCall(_$getDocument, request, options: options);
   }
 
@@ -56,6 +74,31 @@ class FirestoreClient extends $grpc.Client {
     $0.ListDocumentsRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasParent()) {
+        final value = request.parent;
+        final regexps = [_regexp1, _regexp0];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('parent=$value');
+        }
+      }
+      if (request.hasCollectionId()) {
+        final value = request.collectionId;
+        final regexps = [_regexp2];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('collection_id=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createUnaryCall(_$listDocuments, request, options: options);
   }
 
@@ -64,6 +107,24 @@ class FirestoreClient extends $grpc.Client {
     $0.UpdateDocumentRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasDocument() && request.document.hasName()) {
+        final value = request.document.name;
+        final regexps = [_regexp0];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('document.name=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createUnaryCall(_$updateDocument, request, options: options);
   }
 
@@ -72,6 +133,24 @@ class FirestoreClient extends $grpc.Client {
     $0.DeleteDocumentRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasName()) {
+        final value = request.name;
+        final regexps = [_regexp0];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('name=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createUnaryCall(_$deleteDocument, request, options: options);
   }
 
@@ -83,6 +162,24 @@ class FirestoreClient extends $grpc.Client {
     $0.BatchGetDocumentsRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasDatabase()) {
+        final value = request.database;
+        final regexps = [_regexp3];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('database=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createStreamingCall(
         _$batchGetDocuments, $async.Stream.fromIterable([request]),
         options: options);
@@ -93,6 +190,24 @@ class FirestoreClient extends $grpc.Client {
     $0.BeginTransactionRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasDatabase()) {
+        final value = request.database;
+        final regexps = [_regexp3];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('database=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createUnaryCall(_$beginTransaction, request, options: options);
   }
 
@@ -101,6 +216,24 @@ class FirestoreClient extends $grpc.Client {
     $0.CommitRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasDatabase()) {
+        final value = request.database;
+        final regexps = [_regexp3];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('database=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createUnaryCall(_$commit, request, options: options);
   }
 
@@ -109,6 +242,24 @@ class FirestoreClient extends $grpc.Client {
     $0.RollbackRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasDatabase()) {
+        final value = request.database;
+        final regexps = [_regexp3];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('database=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createUnaryCall(_$rollback, request, options: options);
   }
 
@@ -117,6 +268,24 @@ class FirestoreClient extends $grpc.Client {
     $0.RunQueryRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasParent()) {
+        final value = request.parent;
+        final regexps = [_regexp0, _regexp1];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('parent=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createStreamingCall(
         _$runQuery, $async.Stream.fromIterable([request]),
         options: options);
@@ -139,6 +308,24 @@ class FirestoreClient extends $grpc.Client {
     $0.RunAggregationQueryRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasParent()) {
+        final value = request.parent;
+        final regexps = [_regexp0, _regexp1];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('parent=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createStreamingCall(
         _$runAggregationQuery, $async.Stream.fromIterable([request]),
         options: options);
@@ -151,6 +338,24 @@ class FirestoreClient extends $grpc.Client {
     $0.PartitionQueryRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasParent()) {
+        final value = request.parent;
+        final regexps = [_regexp0, _regexp1];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('parent=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createUnaryCall(_$partitionQuery, request, options: options);
   }
 
@@ -160,6 +365,24 @@ class FirestoreClient extends $grpc.Client {
     $async.Stream<$0.WriteRequest> request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasDatabase()) {
+        final value = request.database;
+        final regexps = [_regexp3];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('database=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createStreamingCall(_$write, request, options: options);
   }
 
@@ -169,6 +392,24 @@ class FirestoreClient extends $grpc.Client {
     $async.Stream<$0.ListenRequest> request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasDatabase()) {
+        final value = request.database;
+        final regexps = [_regexp3];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('database=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createStreamingCall(_$listen, request, options: options);
   }
 
@@ -177,6 +418,24 @@ class FirestoreClient extends $grpc.Client {
     $0.ListCollectionIdsRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasParent()) {
+        final value = request.parent;
+        final regexps = [_regexp0, _regexp1];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('parent=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createUnaryCall(_$listCollectionIds, request, options: options);
   }
 
@@ -194,6 +453,24 @@ class FirestoreClient extends $grpc.Client {
     $0.BatchWriteRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasDatabase()) {
+        final value = request.database;
+        final regexps = [_regexp3];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('database=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createUnaryCall(_$batchWrite, request, options: options);
   }
 
@@ -202,8 +479,42 @@ class FirestoreClient extends $grpc.Client {
     $0.CreateDocumentRequest request, {
     $grpc.CallOptions? options,
   }) {
+    {
+      final results = <$core.String>[];
+
+      if (request.hasParent()) {
+        final value = request.parent;
+        final regexps = [_regexp4];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('parent=$value');
+        }
+      }
+      if (request.hasCollectionId()) {
+        final value = request.collectionId;
+        final regexps = [_regexp2];
+        if (regexps.any((r) => r.hasMatch(value))) {
+          results.add('collection_id=$value');
+        }
+      }
+
+      if (results.isNotEmpty) {
+        options = $grpc.CallOptions(metadata: {
+          'x-goog-request-params': results.join('&'),
+        }).mergedWith(options);
+      }
+    }
+
     return $createUnaryCall(_$createDocument, request, options: options);
   }
+
+  final $core.RegExp _regexp0 =
+      $core.RegExp('projects/[^/]*/databases/[^/]*/documents/[^/]*/.*');
+  final $core.RegExp _regexp1 =
+      $core.RegExp('projects/[^/]*/databases/[^/]*/documents');
+  final $core.RegExp _regexp2 = $core.RegExp('[^/]*');
+  final $core.RegExp _regexp3 = $core.RegExp('projects/[^/]*/databases/[^/]*');
+  final $core.RegExp _regexp4 =
+      $core.RegExp('projects/[^/]*/databases/[^/]*/documents/.*');
 
   // method descriptors
 


### PR DESCRIPTION
- generate package:googleapis_firestore_v1 with http routing headers

This is a partial proof-of-concept of supporting http routing headers; for more context, see https://github.com/google/protobuf.dart/issues/1018.

This generated output creates correct headers for unary calls, but doesn't generate correct code for streaming calls. For that, we'll need to augment package:grpc so that generated clients can inspect the first request on the stream and set http headers from that information.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
