### PR TITLE
add a comment to lib/src/display.dart

### DIFF
--- a/pkgs/jot/lib/src/display.dart
+++ b/pkgs/jot/lib/src/display.dart
@@ -4,6 +4,15 @@
 
 // ignore_for_file: implementation_imports
 
+// Note: This file was copied from package:analyzer's
+// `lib/src/dart/element/display_string_builder.dart` file and adopted to
+// make the output correct from the POV of dart format. It will need to be
+// updated periodically from the upstream source-of-truth.
+//
+// We use this file to generate reasonable looking source code from Elements
+// - something that looks like what the user might have written - which we then
+// normalize via dart format.
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';


### PR DESCRIPTION
- add a comment to `lib/src/display.dart`

Adding this comment to provide context on the `lib/src/display.dart` file. This is especially relevant as this file will need to be updated as part of a migration to analyzer v8.0.0 / v9.0.0, which involves several element model changes.

I'd taken a stab at doing the upgrade (w/ @scheglov 's help), but saw a few test failures and things like type aliases not being documented. The upgrade itself would likely only take a day or two; hopefully this comment provides some context.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
