### PR TITLE
Replace pub run with dart run

### DIFF
--- a/pkgs/timezone/tool/encode_tzf.dart
+++ b/pkgs/timezone/tool/encode_tzf.dart
@@ -3,7 +3,7 @@
 /// Usage example:
 ///
 /// ```sh
-/// pub run tool/encode_tzf --zoneinfo path/to/zoneinfo
+/// dart run tool/encode_tzf --zoneinfo path/to/zoneinfo
 /// ```
 library;
 

--- a/pkgs/timezone/tool/get.dart
+++ b/pkgs/timezone/tool/get.dart
@@ -3,10 +3,10 @@
 /// Usage example:
 ///
 /// ```sh
-/// dart pub run tool/get
-/// dart pub run tool/encode_dart lib/data/latest.{tzf,dart}
-/// dart pub run tool/encode_dart lib/data/latest_all.{tzf,dart}
-/// dart pub run tool/encode_dart lib/data/latest_10y.{tzf,dart}
+/// dart run tool/get
+/// dart run tool/encode_dart lib/data/latest.{tzf,dart}
+/// dart run tool/encode_dart lib/data/latest_all.{tzf,dart}
+/// dart run tool/encode_dart lib/data/latest_10y.{tzf,dart}
 /// ```
 library;
 


### PR DESCRIPTION
Following up on https://github.com/dart-lang/pub/issues/4737, this PR replaces deprecated `pub run` commands with `dart run`.