### PR TITLE
Use updated Etc/UTC name

### DIFF
--- a/pkgs/timezone/CHANGELOG.md
+++ b/pkgs/timezone/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1
+
+- Specify `Etc/UTC` as the default timezone (replaces `UTC`)
+
 ## 0.11.0
 
 - Make `Location.offset` a `Duration` instead of an `int`.

--- a/pkgs/timezone/lib/src/env.dart
+++ b/pkgs/timezone/lib/src/env.dart
@@ -9,7 +9,7 @@ import 'tzdb.dart';
 /// File name of the Time Zone default database.
 const String tzDataDefaultFilename = 'latest.tzf';
 
-final _utc = Location('UTC', [minTime], [0], [TimeZone.UTC]);
+final _utc = Location('Etc/UTC', [minTime], [0], [TimeZone.UTC]);
 
 final _database = LocationDatabase();
 late Location _local;

--- a/pkgs/timezone/pubspec.yaml
+++ b/pkgs/timezone/pubspec.yaml
@@ -2,7 +2,7 @@ name: timezone
 description: Time zone databases and time zone aware `DateTime`.
 repository: https://github.com/dart-lang/labs/tree/main/pkgs/timezone
 issue_tracker: https://github.com/dart-lang/labs/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Atimezone
-version: 0.11.0
+version: 0.11.1
 
 environment:
   sdk: ^3.10.0

--- a/pkgs/timezone/test/env_test.dart
+++ b/pkgs/timezone/test/env_test.dart
@@ -1,0 +1,103 @@
+@TestOn('vm')
+library;
+
+import 'package:test/test.dart';
+import 'package:timezone/data/latest.dart';
+import 'package:timezone/timezone.dart';
+
+void main() {
+  group('.UTC', () {
+    test('with name Etc/UTC', () {
+      expect(UTC.name, 'Etc/UTC');
+    });
+
+    test('same instance on every access', () {
+      expect(identical(UTC, UTC), isTrue);
+      final first = UTC;
+      final second = UTC;
+      expect(identical(first, second), isTrue);
+    });
+  });
+
+  group('#getLocation', () {
+    test('throws when database not initialized', () {
+      expect(
+        () => getLocation('America/New_York'),
+        throwsA(
+          const TypeMatcher<LocationNotFoundException>().having(
+            (e) => e.msg,
+            'msg',
+            contains('database'),
+          ),
+        ),
+      );
+    });
+
+    group('when database initialized', () {
+      setUpAll(initializeTimeZones);
+
+      test('retrieves for known name', () {
+        final detroit = getLocation('America/Detroit');
+        expect(detroit.name, 'America/Detroit');
+      });
+
+      test('same instance for same name', () {
+        final a = getLocation('America/Los_Angeles');
+        final b = getLocation('America/Los_Angeles');
+        expect(identical(a, b), isTrue);
+      });
+
+      test('throws for unknown name', () {
+        expect(
+          () => getLocation('non-existent-location'),
+          throwsA(const TypeMatcher<LocationNotFoundException>()),
+        );
+      });
+    });
+  });
+
+  group('#setLocalLocation', () {
+    setUpAll(initializeTimeZones);
+
+    tearDown(() {
+      setLocalLocation(UTC);
+    });
+
+    test('updates local to the given location', () {
+      final detroit = getLocation('America/Detroit');
+      setLocalLocation(detroit);
+      expect(identical(local, detroit), isTrue);
+    });
+
+    test('subsequent local read returns last set location', () {
+      final la = getLocation('America/Los_Angeles');
+      final detroit = getLocation('America/Detroit');
+      setLocalLocation(la);
+      expect(identical(local, la), isTrue);
+      setLocalLocation(detroit);
+      expect(identical(local, detroit), isTrue);
+    });
+  });
+
+  group('#initializeDatabase', () {
+    test('local is Etc/UTC by default', () {
+      initializeTimeZones();
+      expect(identical(local, UTC), isTrue);
+    });
+
+    test('re-initialization resets local to UTC', () {
+      initializeTimeZones();
+      final detroit = getLocation('America/Detroit');
+      setLocalLocation(detroit);
+      expect(identical(local, detroit), isTrue);
+      initializeTimeZones();
+      expect(identical(local, UTC), isTrue);
+    });
+
+    test('populates database so getLocation resolves names', () {
+      initializeTimeZones();
+      final loc = getLocation('America/New_York');
+      expect(loc.name, 'America/New_York');
+    });
+  });
+}


### PR DESCRIPTION
The existing UTC location name is no longer valid. In tests, when no `local` has been declared and defaults are used, it throws:
```
Location with the name "UTC" doesn't exist
  package:timezone/src/location_database.dart 41:7                                  LocationDatabase.get
  package:timezone/src/env.dart 35:20                                               getLocation
```

UTC itself should [link to Etc/UTC based on the spec](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones); this PR uses Etc/UTC directly.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
