### PR TITLE
[appengine] Name Exception subclasses with the `Exception` suffix

### DIFF
--- a/pkgs/appengine/CHANGELOG.md
+++ b/pkgs/appengine/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.13.13-wip
+
+* Rename error classes to use the `Exception` suffix
+  (`AppEngineException`, `NetworkException`, `ProtocolException`,
+  `ServiceException`, `ApplicationException`) to follow Dart conventions for
+  types implementing `Exception`. The old `*Error` names remain available as
+  deprecated type aliases, so this change is non-breaking.
+
 ## 0.13.12
 
 * Upgrade dependency `package:gcloud` to `^0.9.0`.

--- a/pkgs/appengine/lib/src/errors.dart
+++ b/pkgs/appengine/lib/src/errors.dart
@@ -2,47 +2,61 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
 import 'dart:io';
 
-class AppEngineError implements Exception {
+class AppEngineException implements Exception {
   final String message;
 
-  const AppEngineError(this.message);
+  const AppEngineException(this.message);
 
   @override
   String toString() => 'AppEngineException: $message';
 }
 
-class NetworkError extends AppEngineError implements IOException {
-  NetworkError(super.message);
+class NetworkException extends AppEngineException implements IOException {
+  NetworkException(super.message);
 
   @override
-  String toString() => 'NetworkError: $message';
+  String toString() => 'NetworkException: $message';
 }
 
-class ProtocolError extends AppEngineError implements IOException {
-  static const ProtocolError INVALID_RESPONSE =
-      ProtocolError('Invalid response');
+class ProtocolException extends AppEngineException implements IOException {
+  static const ProtocolException INVALID_RESPONSE =
+      ProtocolException('Invalid response');
 
-  const ProtocolError(super.message);
+  const ProtocolException(super.message);
 
   @override
-  String toString() => 'ProtocolError: $message';
+  String toString() => 'ProtocolException: $message';
 }
 
-class ServiceError extends AppEngineError {
+class ServiceException extends AppEngineException {
   final String serviceName;
 
-  ServiceError(super.message, {this.serviceName = 'ServiceError'});
+  ServiceException(super.message, {this.serviceName = 'ServiceException'});
 
   @override
   String toString() => '$serviceName: $message';
 }
 
-class ApplicationError extends AppEngineError {
-  ApplicationError(super.message);
+class ApplicationException extends AppEngineException {
+  ApplicationException(super.message);
 
   @override
-  String toString() => 'ApplicationError: $message';
+  String toString() => 'ApplicationException: $message';
 }
+
+@Deprecated('Use AppEngineException instead')
+typedef AppEngineError = AppEngineException;
+
+@Deprecated('Use NetworkException instead')
+typedef NetworkError = NetworkException;
+
+@Deprecated('Use ProtocolException instead')
+typedef ProtocolError = ProtocolException;
+
+@Deprecated('Use ServiceException instead')
+typedef ServiceError = ServiceException;
+
+@Deprecated('Use ApplicationException instead')
+typedef ApplicationError = ApplicationException;

--- a/pkgs/appengine/lib/src/grpc_api_impl/datastore_impl.dart
+++ b/pkgs/appengine/lib/src/grpc_api_impl/datastore_impl.dart
@@ -511,7 +511,8 @@ class _Codec {
       } else if (part.hasId()) {
         id = part.id.toInt();
       } else {
-        throw const errors.ProtocolError('Neither name nor id present in Key.');
+        throw const errors.ProtocolException(
+            'Neither name nor id present in Key.');
       }
       keyElements[i] = raw.KeyElement(part.kind, id);
     }

--- a/pkgs/appengine/pubspec.yaml
+++ b/pkgs/appengine/pubspec.yaml
@@ -1,5 +1,5 @@
 name: appengine
-version: 0.13.12
+version: 0.13.13-wip
 description: >-
   Support for using Dart as a custom runtime on Google App Engine Flexible
   Environment.

--- a/pkgs/appengine/test/utils/error_matchers.dart
+++ b/pkgs/appengine/test/utils/error_matchers.dart
@@ -8,11 +8,11 @@ import 'package:test/test.dart';
 import 'package:appengine/src/errors.dart';
 import 'package:gcloud/datastore.dart' as datastore;
 
-const isNetworkError = TypeMatcher<NetworkError>();
-const isProtocolError = TypeMatcher<ProtocolError>();
-const isServiceError = TypeMatcher<ServiceError>();
-const isApplicationError = TypeMatcher<AppEngineError>();
-const isAppEngineApplicationError = TypeMatcher<ApplicationError>();
+const isNetworkError = TypeMatcher<NetworkException>();
+const isProtocolError = TypeMatcher<ProtocolException>();
+const isServiceError = TypeMatcher<ServiceException>();
+const isApplicationError = TypeMatcher<AppEngineException>();
+const isAppEngineApplicationError = TypeMatcher<ApplicationException>();
 
 const isDatastoreApplicationError = TypeMatcher<datastore.ApplicationError>();
 const isTransactionAbortedError =


### PR DESCRIPTION
Fixes #99.

Types implementing `Exception` are conventionally named `*Exception`, but the appengine error types were named `*Error`. This renames them:

- `AppEngineError` → `AppEngineException`
- `NetworkError` → `NetworkException`
- `ProtocolError` → `ProtocolException`
- `ServiceError` → `ServiceException`
- `ApplicationError` → `ApplicationException`

The old `*Error` names are retained as `@Deprecated` type aliases, so the change is **non-breaking** — as suggested by @sigurdm in the issue. Internal references and test matchers are updated to the new names; the unrelated `package:gcloud` `ApplicationError` references are left untouched.

`dart analyze` reports no issues and `dart format` is clean. Added a CHANGELOG entry and bumped the version to `0.13.13-wip`.