### PR TITLE
[appengine] Make ClientContext context getter nullable

### DIFF
--- a/pkgs/appengine/CHANGELOG.md
+++ b/pkgs/appengine/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.14.0
+
+* **Breaking:** The `context` getter now returns `ClientContext?` instead of
+  `ClientContext`, returning `null` when called outside of a request handler
+  instead of throwing.
+
 ## 0.13.12
 
 * Upgrade dependency `package:gcloud` to `^0.9.0`.

--- a/pkgs/appengine/lib/appengine.dart
+++ b/pkgs/appengine/lib/appengine.dart
@@ -149,11 +149,12 @@ Future withAppEngineServices(Future Function() callback) {
   return appengine_internal.withAppEngineServices(callback);
 }
 
-/// Returns the [ClientContext] of the current request.
+/// Returns the [ClientContext] of the current request, or `null` if called
+/// outside of a request handler.
 ///
-/// This getter can only be called inside a request handler which was passed to
-/// [runAppEngine].
-ClientContext get context => ss.lookup(_APPENGINE_CONTEXT) as ClientContext;
+/// This getter returns a non-`null` value only when called inside a request
+/// handler which was passed to [runAppEngine].
+ClientContext? get context => ss.lookup(_APPENGINE_CONTEXT) as ClientContext?;
 
 /// Will register for log events produced by `package:logging` and forwards
 /// log records to the AppEngine logging service.

--- a/pkgs/appengine/pubspec.yaml
+++ b/pkgs/appengine/pubspec.yaml
@@ -1,5 +1,5 @@
 name: appengine
-version: 0.13.12
+version: 0.14.0
 description: >-
   Support for using Dart as a custom runtime on Google App Engine Flexible
   Environment.


### PR DESCRIPTION
## What

Changes the top-level `context` getter in `package:appengine` to return
`ClientContext?` instead of `ClientContext`.

## Why

The getter cast the service-scope lookup with `as ClientContext`. When called
outside of a request handler, the lookup returns `null`, so the cast threw a
runtime error instead of yielding `null`. Returning a nullable type lets callers
check for the absence of a request context safely.

Fixes #175

## Notes

- This is a **breaking** API change (non-nullable → nullable return type), so the
  package version is bumped `0.13.12` → `0.14.0` with a CHANGELOG entry.
- `dart analyze` passes; no in-repo call sites or tests use the public getter.
