### PR TITLE
Automatically create PRs for new TZDB version

### DIFF
--- a/.github/workflows/timezone.yml
+++ b/.github/workflows/timezone.yml
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/timezone.yml'
       - 'pkgs/timezone/**'
   schedule:
-    - cron: '0 0 * * 0' # weekly
+    - cron: '0 0 * * *' # daily
 
 defaults:
   run:
@@ -71,7 +71,9 @@ jobs:
       - name: Run refresh script
         run: tool/refresh.sh
 
-      - name: Check for git diff
+      - name: Create PR if necessary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ -n $(git status --porcelain) ]]; then
 

--- a/.github/workflows/timezone.yml
+++ b/.github/workflows/timezone.yml
@@ -69,14 +69,25 @@ jobs:
         run: dart pub get
 
       - name: Run refresh script
-        run: ./tool/refresh.sh
+        run: tool/refresh.sh
 
       - name: Check for git diff
         run: |
           if [[ -n $(git status --porcelain) ]]; then
-            echo "Changes detected after running tool/refresh.sh"
-            git diff
-            exit 1
+
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+            export TZDBVER=$(curl --silent -L -H "Accept: application/vnd.github+json" https://api.github.com/repos/eggert/tz/tags | jq -r '.[0].name')
+          
+            # Exit if the data already exists, or a PR has already been generated
+            (git rev-parse --verify "tzdb-${TZDBVER}" 2>/dev/null 1>&2) && echo "PR exists" && exit
+            
+            git checkout -b "tzdb-${TZDBVER}"
+            git add .
+            git commit -m "${TZDBVER}"
+            git push --set-upstream origin "tzdb-${TZDBVER}"
+            gh pr create --title "TZDB ${TZDBVER}" --body "See [here](https://github.com/eggert/tz/blob/main/NEWS) for the latest changes made to tz."
           else
             echo "No changes detected."
           fi


### PR DESCRIPTION
The TZDB update checker is currently broken: 
<img width="430" height="127" alt="image" src="https://github.com/user-attachments/assets/0d5a0402-0780-4f51-9fa2-4c74c589ea33" />

It has already missed two TZDB releases since March (2026a and 2026b).

Instead of failing CI, it should generate a PR.

@mosuem 

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
