### PR TITLE
Add bot name and email for PRs

### DIFF
--- a/.github/workflows/timezone.yml
+++ b/.github/workflows/timezone.yml
@@ -89,6 +89,8 @@ jobs:
         uses: peter-evans/create-pull-request@6fff569d741c6b8131d2a49663b16573ef90be31
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          committer: dart-ecosystem-bot <${{ vars.ECOSYSTEM_BOT_CLIENT_ID }}+dart-ecosystem-bot[bot]@users.noreply.github.com>
+          author: dart-ecosystem-bot <${{ vars.ECOSYSTEM_BOT_CLIENT_ID }}+dart-ecosystem-bot[bot]@users.noreply.github.com>
           commit-message: "Update time zone data to ${{ steps.refresh.outputs.tz_version }}"
           branch: "update-tzdb-${{ steps.refresh.outputs.tz_version }}"
           title: "[refresh.sh] Update time zone data to TZDB ${{ steps.refresh.outputs.tz_version }}"

--- a/.github/workflows/timezone.yml
+++ b/.github/workflows/timezone.yml
@@ -89,8 +89,8 @@ jobs:
         uses: peter-evans/create-pull-request@6fff569d741c6b8131d2a49663b16573ef90be31
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          committer: dart-ecosystem-bot <${{ vars.ECOSYSTEM_BOT_CLIENT_ID }}+dart-ecosystem-bot[bot]@users.noreply.github.com>
-          author: dart-ecosystem-bot <${{ vars.ECOSYSTEM_BOT_CLIENT_ID }}+dart-ecosystem-bot[bot]@users.noreply.github.com>
+          committer: dart-ecosystem-bot <dart-ecosystem-bot@google.com>
+          author: dart-ecosystem-bot <dart-ecosystem-bot@google.com>
           commit-message: "Update time zone data to ${{ steps.refresh.outputs.tz_version }}"
           branch: "update-tzdb-${{ steps.refresh.outputs.tz_version }}"
           title: "[refresh.sh] Update time zone data to TZDB ${{ steps.refresh.outputs.tz_version }}"


### PR DESCRIPTION
Otherwise it defaults to the github bot or the name of the person clicking on "run workflow".

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
