### PR TITLE
Fix deprecated `app-id` input in `refresh-check` job

### DIFF
--- a/.github/workflows/timezone.yml
+++ b/.github/workflows/timezone.yml
@@ -85,15 +85,27 @@ jobs:
         id: refresh
         run: tool/refresh.sh
 
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if [ -n "$(git status --porcelain .)" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install changelog updater
+        if: steps.check_changes.outputs.changed == 'true'
         run: |
           dart install --git-path pkgs/repo_manage https://github.com/dart-lang/ecosystem.git
           echo "$HOME/.local/state/Dart/install/bin" >> $GITHUB_PATH
           
       - name: Update changelog
+        if: steps.check_changes.outputs.changed == 'true'
         run: report changelog "Update timezone database to ${{ steps.refresh.outputs.tz_version }}."
 
       - name: Create Pull Request
+        if: steps.check_changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@6fff569d741c6b8131d2a49663b16573ef90be31
         with:
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/timezone.yml
+++ b/.github/workflows/timezone.yml
@@ -67,7 +67,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ vars.ECOSYSTEM_BOT_CLIENT_ID }}
+          client-id: ${{ vars.ECOSYSTEM_BOT_CLIENT_ID }}
           private-key: ${{ secrets.ECOSYSTEM_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
Also only create a PR if there are changes from the refresh.sh workflow.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
