### PR TITLE
[gcloud] Support GCS preconditions for object write/delete/copy

### DIFF
--- a/pkgs/gcloud/CHANGELOG.md
+++ b/pkgs/gcloud/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.1-wip
+
+- Support the `ifGenerationMatch` and `ifMetagenerationMatch` preconditions on
+  the object write, delete, metadata update and copy operations, enabling
+  optimistic concurrency control.
+
 ## 0.9.0
 
 - Support `orderingKey` on pub/sub's `Message` type.

--- a/pkgs/gcloud/lib/src/storage_impl.dart
+++ b/pkgs/gcloud/lib/src/storage_impl.dart
@@ -106,7 +106,10 @@ class _StorageImpl implements Storage {
   }
 
   @override
-  Future copyObject(String src, String dest, {ObjectMetadata? metadata}) {
+  Future copyObject(String src, String dest,
+      {ObjectMetadata? metadata,
+      String? ifGenerationMatch,
+      int? ifMetagenerationMatch}) {
     var srcName = _AbsoluteName.parse(src);
     var destName = _AbsoluteName.parse(dest);
     metadata ??= _ObjectMetadata();
@@ -114,7 +117,9 @@ class _StorageImpl implements Storage {
     final object = objectMetadata._object;
     return _api.objects
         .copy(object, srcName.bucketName, srcName.objectName,
-            destName.bucketName, destName.objectName)
+            destName.bucketName, destName.objectName,
+            ifGenerationMatch: ifGenerationMatch,
+            ifMetagenerationMatch: ifMetagenerationMatch?.toString())
         .then((_) => null);
   }
 
@@ -169,7 +174,9 @@ class _BucketImpl implements Bucket {
       ObjectMetadata? metadata,
       Acl? acl,
       PredefinedAcl? predefinedAcl,
-      String? contentType}) {
+      String? contentType,
+      String? ifGenerationMatch,
+      int? ifMetagenerationMatch}) {
     storage_api.Object object;
     if (metadata == null) {
       metadata = _ObjectMetadata(acl: acl, contentType: contentType);
@@ -199,8 +206,8 @@ class _BucketImpl implements Bucket {
     // Fill properties not passed in metadata.
     object.name = objectName;
 
-    var sink = _MediaUploadStreamSink(
-        _api, bucketName, objectName, object, predefinedName, length);
+    var sink = _MediaUploadStreamSink(_api, bucketName, objectName, object,
+        predefinedName, length, ifGenerationMatch, ifMetagenerationMatch);
     return sink;
   }
 
@@ -209,13 +216,17 @@ class _BucketImpl implements Bucket {
       {ObjectMetadata? metadata,
       Acl? acl,
       PredefinedAcl? predefinedAcl,
-      String? contentType}) {
+      String? contentType,
+      String? ifGenerationMatch,
+      int? ifMetagenerationMatch}) {
     var sink = write(objectName,
         length: bytes.length,
         metadata: metadata,
         acl: acl,
         predefinedAcl: predefinedAcl,
-        contentType: contentType) as _MediaUploadStreamSink;
+        contentType: contentType,
+        ifGenerationMatch: ifGenerationMatch,
+        ifMetagenerationMatch: ifMetagenerationMatch) as _MediaUploadStreamSink;
     sink.add(bytes);
     return sink.close();
   }
@@ -256,8 +267,11 @@ class _BucketImpl implements Bucket {
   }
 
   @override
-  Future delete(String objectName) {
-    return _api.objects.delete(bucketName, objectName);
+  Future delete(String objectName,
+      {String? ifGenerationMatch, int? ifMetagenerationMatch}) {
+    return _api.objects.delete(bucketName, objectName,
+        ifGenerationMatch: ifGenerationMatch,
+        ifMetagenerationMatch: ifMetagenerationMatch?.toString());
   }
 
   @override
@@ -282,7 +296,8 @@ class _BucketImpl implements Bucket {
   }
 
   @override
-  Future updateMetadata(String objectName, ObjectMetadata metadata) {
+  Future updateMetadata(String objectName, ObjectMetadata metadata,
+      {String? ifGenerationMatch, int? ifMetagenerationMatch}) {
     // TODO: support other ObjectMetadata implementations?
     var md = metadata as _ObjectMetadata;
     var object = md._object;
@@ -293,7 +308,9 @@ class _BucketImpl implements Bucket {
     if (object.acl == null && _defaultObjectAcl != null) {
       object.acl = _defaultObjectAcl!._toObjectAccessControlList();
     }
-    return _api.objects.update(object, bucketName, objectName);
+    return _api.objects.update(object, bucketName, objectName,
+        ifGenerationMatch: ifGenerationMatch,
+        ifMetagenerationMatch: ifMetagenerationMatch?.toString());
   }
 
   Future<storage_api.Objects> _listObjects(String bucketName, String? prefix,
@@ -531,6 +548,8 @@ class _MediaUploadStreamSink implements StreamSink<List<int>> {
   final storage_api.Object _object;
   final String? _predefinedAcl;
   final int? _length;
+  final String? _ifGenerationMatch;
+  final int? _ifMetagenerationMatch;
   final BytesBuilder _buffer = BytesBuilder();
   final _controller = StreamController<List<int>>(sync: true);
   late StreamSubscription _subscription;
@@ -542,8 +561,15 @@ class _MediaUploadStreamSink implements StreamSink<List<int>> {
   static const int _stateDecidedResumable = 2;
   int? _state;
 
-  _MediaUploadStreamSink(this._api, this._bucketName, this._objectName,
-      this._object, this._predefinedAcl, this._length) {
+  _MediaUploadStreamSink(
+      this._api,
+      this._bucketName,
+      this._objectName,
+      this._object,
+      this._predefinedAcl,
+      this._length,
+      this._ifGenerationMatch,
+      this._ifMetagenerationMatch) {
     if (_length != null) {
       // If the length is known in advance decide on the upload strategy
       // immediately
@@ -651,6 +677,8 @@ class _MediaUploadStreamSink implements StreamSink<List<int>> {
         _bucketName,
         name: _objectName,
         predefinedAcl: _predefinedAcl,
+        ifGenerationMatch: _ifGenerationMatch,
+        ifMetagenerationMatch: _ifMetagenerationMatch?.toString(),
         uploadMedia: media,
         uploadOptions: storage_api.UploadOptions.defaultOptions,
       );
@@ -667,6 +695,8 @@ class _MediaUploadStreamSink implements StreamSink<List<int>> {
         .insert(_object, _bucketName,
             name: _objectName,
             predefinedAcl: _predefinedAcl,
+            ifGenerationMatch: _ifGenerationMatch,
+            ifMetagenerationMatch: _ifMetagenerationMatch?.toString(),
             uploadMedia: media,
             uploadOptions: storage_api.UploadOptions.resumable)
         .then((response) {

--- a/pkgs/gcloud/lib/storage.dart
+++ b/pkgs/gcloud/lib/storage.dart
@@ -563,7 +563,17 @@ abstract class Storage {
   /// The names of [src] and [dest] must be absolute.
   ///
   /// [metadata] can be used to overwrite metadata properties.
-  Future copyObject(String src, String dest, {ObjectMetadata? metadata});
+  ///
+  /// The [ifGenerationMatch] and [ifMetagenerationMatch] preconditions, if
+  /// given, apply to the *destination* object and make the copy conditional on
+  /// its current generation / metageneration. This can be used for optimistic
+  /// concurrency control. An [ifGenerationMatch] of `'0'` limits the copy to
+  /// the case where the destination object does not yet exist. See
+  /// https://cloud.google.com/storage/docs/request-preconditions for details.
+  Future copyObject(String src, String dest,
+      {ObjectMetadata? metadata,
+      String? ifGenerationMatch,
+      int? ifMetagenerationMatch});
 }
 
 /// Information on a specific object.
@@ -731,6 +741,13 @@ abstract class Bucket {
   /// ACL as well, this ACL with be followed by the expansion of
   /// [predefinedAcl].
   ///
+  /// The [ifGenerationMatch] and [ifMetagenerationMatch] preconditions, if
+  /// given, make the write conditional on the current generation /
+  /// metageneration of the object being replaced. This can be used for
+  /// optimistic concurrency control. An [ifGenerationMatch] of `'0'` limits
+  /// the write to the case where the object does not yet exist. See
+  /// https://cloud.google.com/storage/docs/request-preconditions for details.
+  ///
   /// Returns a `StreamSink` where the object content can be written. When
   /// The object content has been written the `StreamSink` completes with
   /// an `ObjectInfo` instance with the information on the object created.
@@ -739,7 +756,9 @@ abstract class Bucket {
       ObjectMetadata? metadata,
       Acl? acl,
       PredefinedAcl? predefinedAcl,
-      String? contentType});
+      String? contentType,
+      String? ifGenerationMatch,
+      int? ifMetagenerationMatch});
 
   /// Create an new object in the bucket with specified content.
   ///
@@ -753,7 +772,9 @@ abstract class Bucket {
       {ObjectMetadata? metadata,
       Acl? acl,
       PredefinedAcl? predefinedAcl,
-      String? contentType});
+      String? contentType,
+      String? ifGenerationMatch,
+      int? ifMetagenerationMatch});
 
   /// Read object content as byte stream.
   ///
@@ -772,13 +793,27 @@ abstract class Bucket {
 
   /// Delete an object.
   ///
+  /// The [ifGenerationMatch] and [ifMetagenerationMatch] preconditions, if
+  /// given, make the deletion conditional on the current generation /
+  /// metageneration of the object. This can be used for optimistic concurrency
+  /// control. See
+  /// https://cloud.google.com/storage/docs/request-preconditions for details.
+  ///
   // TODO: More documentation
-  Future delete(String name);
+  Future delete(String name,
+      {String? ifGenerationMatch, int? ifMetagenerationMatch});
 
   /// Update object metadata.
   ///
+  /// The [ifGenerationMatch] and [ifMetagenerationMatch] preconditions, if
+  /// given, make the update conditional on the current generation /
+  /// metageneration of the object. This can be used for optimistic concurrency
+  /// control. See
+  /// https://cloud.google.com/storage/docs/request-preconditions for details.
+  ///
   // TODO: More documentation
-  Future updateMetadata(String objectName, ObjectMetadata metadata);
+  Future updateMetadata(String objectName, ObjectMetadata metadata,
+      {String? ifGenerationMatch, int? ifMetagenerationMatch});
 
   /// List objects in the bucket.
   ///

--- a/pkgs/gcloud/pubspec.yaml
+++ b/pkgs/gcloud/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.9.0
+version: 0.9.1-wip
 description: >-
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.
 repository: https://github.com/dart-lang/labs/tree/main/pkgs/gcloud

--- a/pkgs/gcloud/test/storage/storage_test.dart
+++ b/pkgs/gcloud/test/storage/storage_test.dart
@@ -302,6 +302,23 @@ void main() {
       });
     });
 
+    test('copy-with-preconditions', () {
+      withMockClient((mock, api) {
+        mock.register(
+            'POST', 'b/srcBucket/o/srcObject/copyTo/b/destBucket/o/destObject',
+            expectAsync1((request) {
+          expect(request.url.queryParameters['ifGenerationMatch'], '0');
+          expect(request.url.queryParameters['ifMetagenerationMatch'], '9');
+          return mock.respond(storage.Object()..name = 'destObject');
+        }));
+        expect(
+            api.copyObject(
+                'gs://srcBucket/srcObject', 'gs://destBucket/destObject',
+                ifGenerationMatch: '0', ifMetagenerationMatch: 9),
+            completion(isNull));
+      });
+    });
+
     test('copy-invalid-args', () {
       withMockClient((mock, api) {
         expect(() => api.copyObject('a', 'b'), throwsA(isFormatException));
@@ -1027,6 +1044,68 @@ void main() {
           expect(info.metadata.acl!.entries[1].scope is AccountScope, isTrue);
           expect(info.metadata.acl!.entries[2].scope is OpaqueScope, isTrue);
         }));
+      });
+    });
+
+    group('preconditions', () {
+      test('write', () {
+        withMockClient((mock, api) {
+          var bytes = [1, 2, 3];
+          mock.registerUpload('POST', 'b/$bucketName/o',
+              expectAsync1((request) {
+            expect(request.url.queryParameters['ifGenerationMatch'], '0');
+            expect(request.url.queryParameters['ifMetagenerationMatch'], '7');
+            return mock
+                .processNormalMediaUpload(request)
+                .then(expectAsync1((mediaUpload) {
+              var object =
+                  storage.Object.fromJson(jsonDecode(mediaUpload.json) as Map);
+              expect(object.name, objectName);
+              return mock.respond(storage.Object()..name = objectName);
+            }));
+          }));
+
+          var bucket = api.bucket(bucketName);
+          expect(
+              bucket.writeBytes(objectName, bytes,
+                  ifGenerationMatch: '0', ifMetagenerationMatch: 7),
+              completion(isA<ObjectInfo>()));
+        });
+      });
+
+      test('delete', () {
+        withMockClient((mock, api) {
+          mock.register('DELETE', 'b/$bucketName/o/$objectName',
+              expectAsync1((request) {
+            expect(request.url.queryParameters['ifGenerationMatch'], '1234');
+            expect(request.url.queryParameters['ifMetagenerationMatch'], '5');
+            return mock.respondEmpty();
+          }));
+
+          var bucket = api.bucket(bucketName);
+          expect(
+              bucket.delete(objectName,
+                  ifGenerationMatch: '1234', ifMetagenerationMatch: 5),
+              completes);
+        });
+      });
+
+      test('updateMetadata', () {
+        withMockClient((mock, api) {
+          mock.register('PUT', 'b/$bucketName/o/$objectName',
+              expectAsync1((request) {
+            expect(request.url.queryParameters['ifGenerationMatch'], '42');
+            expect(request.url.queryParameters['ifMetagenerationMatch'], '3');
+            return mock.respond(storage.Object()..name = objectName);
+          }));
+
+          var bucket = api.bucket(bucketName);
+          expect(
+              bucket.updateMetadata(
+                  objectName, ObjectMetadata(contentType: 'mime/type'),
+                  ifGenerationMatch: '42', ifMetagenerationMatch: 3),
+              completes);
+        });
       });
     });
 


### PR DESCRIPTION
Adds optional `ifGenerationMatch` and `ifMetagenerationMatch` parameters to the object write, delete, metadata-update and copy operations, enabling optimistic concurrency control as described at https://cloud.google.com/storage/docs/request-preconditions.

The parameter types mirror the existing `ObjectGeneration` API (`objectGeneration` is a `String`, `metaGeneration` is an `int`), so a value read from `ObjectInfo.generation` can be passed straight back as a precondition without conversion. An `ifGenerationMatch` of `0` (as the string `'0'`) limits a write/copy to the case where the object does not yet exist.

The change is purely additive and non-breaking.

Fixes #184