### PR TITLE
[timezone] Validate header offsets and lengths in tzdb deserializer

### DIFF
--- a/pkgs/timezone/CHANGELOG.md
+++ b/pkgs/timezone/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.11.1-wip
 
-- Update timezone database to 2026b.
 - Update timezone database to 2026c.
+- Validate header offsets and lengths in tzdb deserializer.
 
 ## 0.11.1
 

--- a/pkgs/timezone/lib/src/tzdb.dart
+++ b/pkgs/timezone/lib/src/tzdb.dart
@@ -45,15 +45,44 @@ Iterable<Location> tzdbDeserialize(List<int> rawData) sync* {
 
   var offset = 0;
   while (offset < data.length) {
+    if (data.length - offset < 8) {
+      throw FormatException(
+        'Malformed tzdb: truncated chunk header at offset $offset',
+      );
+    }
     final length = bdata.getUint32(offset);
     // u32 _pad;
-    assert((length % 8) == 0);
+    if (length % 8 != 0) {
+      throw FormatException(
+        'Malformed tzdb: chunk length $length at offset $offset is not '
+        '8-byte aligned',
+      );
+    }
     offset += 8;
+    if (length > data.length - offset) {
+      throw FormatException(
+        'Malformed tzdb: chunk length $length at offset $offset exceeds '
+        'buffer size ${data.length}',
+      );
+    }
 
     yield _deserializeLocation(
       Uint8List.sublistView(data, offset, offset + length),
     );
     offset += length;
+  }
+}
+
+/// Throws [FormatException] if the byte range `[offset, offset + length)` does
+/// not lie entirely within a buffer of size [total]. Used to validate
+/// untrusted offsets/lengths read from a serialized location header before
+/// they are used to index into the buffer.
+void _checkRange(int offset, int length, int total, String name) {
+  if (offset < 0 || offset > total || length < 0 || length > total - offset) {
+    throw FormatException(
+      'Malformed tzdb: $name section [$offset, +$length) is outside '
+      '$total-byte location chunk',
+    );
   }
 }
 
@@ -163,6 +192,12 @@ Location _deserializeLocation(Uint8List data) {
   //       u32 transitionsOffset;
   //       u32 transitionsLength;
   //     } header;
+  final total = data.length;
+  if (total < 32) {
+    throw FormatException(
+      'Malformed tzdb: location chunk is $total bytes, header requires 32',
+    );
+  }
   final nameOffset = bdata.getUint32(0);
   final nameLength = bdata.getUint32(4);
   final abbreviationsOffset = bdata.getUint32(8);
@@ -171,6 +206,11 @@ Location _deserializeLocation(Uint8List data) {
   final zonesLength = bdata.getUint32(20);
   final transitionsOffset = bdata.getUint32(24);
   final transitionsLength = bdata.getUint32(28);
+
+  _checkRange(nameOffset, nameLength, total, 'name');
+  _checkRange(abbreviationsOffset, abbreviationsLength, total, 'abbreviations');
+  _checkRange(zonesOffset, zonesLength * 8, total, 'zones');
+  _checkRange(transitionsOffset, transitionsLength * 9, total, 'transitions');
 
   assert(_allAscii(data, nameOffset, nameOffset + nameLength));
   final name = String.fromCharCodes(data, nameOffset, nameOffset + nameLength);

--- a/pkgs/timezone/test/tzdb_test.dart
+++ b/pkgs/timezone/test/tzdb_test.dart
@@ -1,0 +1,61 @@
+@TestOn('vm')
+library;
+
+import 'dart:typed_data';
+import 'package:test/test.dart';
+import 'package:timezone/src/tzdb.dart';
+
+void main() {
+  group('tzdbDeserialize validation', () {
+    test('throws FormatException on truncated chunk header', () {
+      final data = [1, 2, 3]; // less than 8 bytes
+      expect(
+        () => tzdbDeserialize(data).toList(),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws FormatException when chunk length is not 8-byte aligned', () {
+      final data = Uint8List(16);
+      ByteData.sublistView(data).setUint32(0, 5); // 5 is not divisible by 8
+      expect(
+        () => tzdbDeserialize(data).toList(),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws FormatException when chunk length exceeds buffer size', () {
+      final data = Uint8List(8);
+      ByteData.sublistView(data).setUint32(0, 96); // 96 > buffer size remaining
+      expect(
+        () => tzdbDeserialize(data).toList(),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test(
+      'throws FormatException when location chunk is smaller than 32 bytes',
+      () {
+        final data = Uint8List(16);
+        ByteData.sublistView(data).setUint32(0, 8); // chunk length = 8 bytes
+        expect(
+          () => tzdbDeserialize(data).toList(),
+          throwsA(isA<FormatException>()),
+        );
+      },
+    );
+
+    test('throws FormatException on out-of-bounds section offsets', () {
+      final data = Uint8List(40);
+      final bdata = ByteData.sublistView(data);
+      bdata.setUint32(0, 32); // chunk length = 32
+      // Set zonesOffset (at header offset 16) to an out-of-bounds value
+      bdata.setUint32(24, 0x70000000); // zonesOffset = 0x70000000
+
+      expect(
+        () => tzdbDeserialize(data).toList(),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Adds bounds checks for chunk headers and location header section fields (name, abbreviations, zones, and transitions) in `tzdbDeserialize` and `_deserializeLocation`.

If any header offset or length falls outside the location chunk or buffer boundaries, a `FormatException` is thrown instead of allowing an unhandled `RangeError` to propagate.

Also adds unit tests for malformed `tzdb` headers in `tzdb_test.dart`.

Fixes b/528608584