### PR TITLE
chore: harden GitHub Actions workflows against Zizmor findings

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,3 +12,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/appengine.yml
+++ b/.github/workflows/appengine.yml
@@ -30,6 +30,8 @@ jobs:
         sdk: [stable, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/gcloud.yml
+++ b/.github/workflows/gcloud.yml
@@ -30,6 +30,8 @@ jobs:
         sdk: [stable, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/groundskeeper.yml
+++ b/.github/workflows/groundskeeper.yml
@@ -1,4 +1,6 @@
 name: Groundskeeper
+permissions:
+  contents: read
 
 on:
   schedule:
@@ -21,11 +23,11 @@ jobs:
           - native_synchronization
           - timezone
           - unix_api
-    uses: dart-lang/ecosystem/.github/workflows/groundskeeper.yml@main
+    uses: dart-lang/ecosystem/.github/workflows/groundskeeper.yml@ed9c592c1d35106c0a8a52044426515017a60646
     with:
       directory: pkgs/${{ matrix.package }}
       branch: auto-tidy-${{ matrix.package }}
       title: 'Tidy: package:${{ matrix.package }}'
       update-changelog: true
       changelog-message: 'Automated formatting and fixes.'
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -1,5 +1,6 @@
 name: Health
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -8,7 +9,7 @@ on:
 
 jobs:
   health:
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@ed9c592c1d35106c0a8a52044426515017a60646
     with:
       ignore_coverage: "**.mock.dart,**.g.dart"
       ignore_license: "**.mock.dart,**.g.dart,**.mocks.dart"

--- a/.github/workflows/io_file.yml
+++ b/.github/workflows/io_file.yml
@@ -1,6 +1,7 @@
 name: package:io_file
 
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -28,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: dev
@@ -44,6 +47,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -55,6 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: dev
@@ -69,6 +76,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -86,6 +95,8 @@ jobs:
         working-directory: pkgs/io_file/mobile_test
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: master
@@ -112,6 +123,8 @@ jobs:
         working-directory: pkgs/io_file/mobile_test
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: master
@@ -128,6 +141,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: dev

--- a/.github/workflows/jot.yml
+++ b/.github/workflows/jot.yml
@@ -30,6 +30,8 @@ jobs:
         sdk: [stable, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/native_synchronization.yml
+++ b/.github/workflows/native_synchronization.yml
@@ -30,6 +30,8 @@ jobs:
         sdk: [stable, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -4,10 +4,11 @@
 # original workflow couldn't.
 
 name: Comment on the pull request
-permissions: read-all
+permissions:
+  contents: read
 
 on:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: 
       - Publish
       - Health
@@ -16,6 +17,6 @@ on:
 
 jobs:
   upload:
-    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@ed9c592c1d35106c0a8a52044426515017a60646
     permissions:
       pull-requests: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,8 @@
 # A CI configuration to auto-publish pub packages.
 
 name: Publish
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -11,7 +13,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository_owner == 'dart-lang' }}
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@ed9c592c1d35106c0a8a52044426515017a60646
     with:
       write-comments: false
     permissions:

--- a/.github/workflows/timezone.yml
+++ b/.github/workflows/timezone.yml
@@ -1,5 +1,6 @@
 name: package:timezone
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on all PRs (against any branch) and on pushes to the main branch.
@@ -30,6 +31,8 @@ jobs:
         sdk: [stable, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -43,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: dev
@@ -69,10 +74,13 @@ jobs:
         with:
           client-id: ${{ vars.ECOSYSTEM_BOT_CLIENT_ID }}
           private-key: ${{ secrets.ECOSYSTEM_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
       
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
@@ -102,7 +110,9 @@ jobs:
           
       - name: Update changelog
         if: steps.check_changes.outputs.changed == 'true'
-        run: report changelog "Update timezone database to ${{ steps.refresh.outputs.tz_version }}."
+        run: report changelog "Update timezone database to ${STEPS_REFRESH_OUTPUTS_TZ_VERSION}."
+        env:
+          STEPS_REFRESH_OUTPUTS_TZ_VERSION: ${{ steps.refresh.outputs.tz_version }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.changed == 'true'

--- a/.github/workflows/unix_api.yml
+++ b/.github/workflows/unix_api.yml
@@ -1,6 +1,7 @@
 name: package:unix_api
 
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -26,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
       - run: dart pub get
       - run: dart analyze --fatal-infos
@@ -41,6 +44,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
       - run: dart pub get
       - run: dart run tool/generate.dart
@@ -55,6 +60,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}


### PR DESCRIPTION
- Pin dart-lang/ecosystem workflows to full commit SHA
- Add top-level permissions: contents: read where missing
- Set persist-credentials: false on actions/checkout steps
- Restrict GitHub App token permissions in timezone workflow
- Ignore dangerous-triggers for post_summaries workflow_run and secrets-inherit for groundskeeper
