### PR TITLE
Add lockfile provenance policy to package:sigstore

### DIFF
--- a/pkgs/sigstore/lib/sigstore.dart
+++ b/pkgs/sigstore/lib/sigstore.dart
@@ -6,6 +6,8 @@
 library;
 
 export 'src/asn1.dart' show Asn1Reader;
+export 'src/lockfile_policy.dart'
+    show PackageProvenanceException, ProvenancePolicy;
 export 'src/models.dart';
 export 'src/trusted_root.dart'
     show

--- a/pkgs/sigstore/lib/src/lockfile_policy.dart
+++ b/pkgs/sigstore/lib/src/lockfile_policy.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_semver/pub_semver.dart';
+
+import 'models.dart';
+
+/// Exception thrown when package integrity or provenance policies fail.
+class PackageProvenanceException implements Exception {
+  final String message;
+  PackageProvenanceException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+/// Enforces security policies between the current package and previous locks.
+class ProvenancePolicy {
+  /// Enforces downgrade prevention and repository continuity.
+  ///
+  /// 1. Downgrade attack prevention: If [packageName] was previously locked
+  ///    with signed provenance ([previousLockedProvenance] != null),
+  ///    subsequent versions must also have valid signed provenance
+  ///    ([currentProvenance] != null).
+  ///
+  /// 2. Repository switch alert: If the repository changes from
+  ///    [previousLockedProvenance], a security warning or error is issued.
+  static void enforcePolicy({
+    required String packageName,
+    required Version version,
+    required ProvenanceInfo? currentProvenance,
+    required ProvenanceInfo? previousLockedProvenance,
+    bool fatalOnRepoMismatch = false,
+    void Function(String message)? onWarning,
+  }) {
+    if (previousLockedProvenance != null && currentProvenance == null) {
+      throw PackageProvenanceException('''
+Package "$packageName" version $version is not signed with provenance.
+However, previously locked versions of this package were signed by:
+  ${previousLockedProvenance.repository}
+
+Downgrading from a signed package to an unsigned package is prohibited.
+''');
+    }
+
+    if (previousLockedProvenance != null && currentProvenance != null) {
+      if (!_repositoriesMatch(
+        previousLockedProvenance.repository,
+        currentProvenance.repository,
+      )) {
+        final message =
+            'Package "$packageName" provenance repository changed from '
+            '"${previousLockedProvenance.repository}" to '
+            '"${currentProvenance.repository}".';
+        if (fatalOnRepoMismatch) {
+          throw PackageProvenanceException(
+            '$message\n'
+            'Repository changes for signed packages require verification.',
+          );
+        } else if (onWarning != null) {
+          onWarning(message);
+        }
+      }
+    }
+  }
+
+  static bool _repositoriesMatch(String a, String b) {
+    final normA = a
+        .trim()
+        .toLowerCase()
+        .replaceAll(RegExp(r'\.git$'), '')
+        .replaceAll(RegExp(r'/+$'), '');
+    final normB = b
+        .trim()
+        .toLowerCase()
+        .replaceAll(RegExp(r'\.git$'), '')
+        .replaceAll(RegExp(r'/+$'), '');
+    return normA == normB || normA.endsWith(normB) || normB.endsWith(normA);
+  }
+}

--- a/pkgs/sigstore/test/lockfile_policy_test.dart
+++ b/pkgs/sigstore/test/lockfile_policy_test.dart
@@ -1,0 +1,94 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_semver/pub_semver.dart';
+import 'package:sigstore/sigstore.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('allows signed package when previously locked version was signed', () {
+    final prev = ProvenanceInfo(
+      repository: 'https://github.com/mosuem/helpful',
+      ref: 'refs/tags/v0.1.3',
+    );
+    final current = ProvenanceInfo(
+      repository: 'https://github.com/mosuem/helpful',
+      ref: 'refs/tags/v0.1.4',
+    );
+
+    expect(
+      () => ProvenancePolicy.enforcePolicy(
+        packageName: 'helpful',
+        version: Version(0, 1, 4),
+        currentProvenance: current,
+        previousLockedProvenance: prev,
+      ),
+      returnsNormally,
+    );
+  });
+
+  test('blocks downgrade attack when new version is unsigned', () {
+    final prev = ProvenanceInfo(
+      repository: 'https://github.com/mosuem/helpful',
+      ref: 'refs/tags/v0.1.3',
+    );
+
+    expect(
+      () => ProvenancePolicy.enforcePolicy(
+        packageName: 'helpful',
+        version: Version(0, 1, 4),
+        currentProvenance: null,
+        previousLockedProvenance: prev,
+      ),
+      throwsA(isA<PackageProvenanceException>()),
+    );
+  });
+
+  test('detects repository switch when configured as fatal', () {
+    final prev = ProvenanceInfo(
+      repository: 'https://github.com/mosuem/helpful',
+      ref: 'refs/tags/v0.1.3',
+    );
+    final current = ProvenanceInfo(
+      repository: 'https://github.com/attacker/helpful',
+      ref: 'refs/tags/v0.1.4',
+    );
+
+    expect(
+      () => ProvenancePolicy.enforcePolicy(
+        packageName: 'helpful',
+        version: Version(0, 1, 4),
+        currentProvenance: current,
+        previousLockedProvenance: prev,
+        fatalOnRepoMismatch: true,
+      ),
+      throwsA(isA<PackageProvenanceException>()),
+    );
+  });
+
+  test('invokes onWarning when repository switch is non-fatal', () {
+    final prev = ProvenanceInfo(
+      repository: 'https://github.com/mosuem/helpful',
+      ref: 'refs/tags/v0.1.3',
+    );
+    final current = ProvenanceInfo(
+      repository: 'https://github.com/attacker/helpful',
+      ref: 'refs/tags/v0.1.4',
+    );
+
+    var warningReceived = false;
+    ProvenancePolicy.enforcePolicy(
+      packageName: 'helpful',
+      version: Version(0, 1, 4),
+      currentProvenance: current,
+      previousLockedProvenance: prev,
+      fatalOnRepoMismatch: false,
+      onWarning: (msg) {
+        warningReceived = true;
+      },
+    );
+
+    expect(warningReceived, isTrue);
+  });
+}


### PR DESCRIPTION
Part of the Sigstore attestation verification stack (stacked on #368).

This PR adds:
- `ProvenancePolicy` for downgrade prevention (preventing packages previously locked with provenance from downgrading to unsigned packages) and repository switch detection.
- `PackageProvenanceException`.
- Comprehensive unit tests in `pkgs/sigstore/test/lockfile_policy_test.dart`.